### PR TITLE
Fix Windows Studio agent runtime issues

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
   "types": "./dist/index.d.ts",
   "files": ["dist", "README.md"],
   "scripts": {
-    "build": "tsc -p tsconfig.json && chmod +x dist/bin.js",
+    "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke": "node dist/smoke.js",
     "test": "node --test test/"

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -1267,7 +1267,20 @@ export async function startStudioServer(ctx: CliContext, port: number): Promise<
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       const code = (e as { code?: string }).code ?? 'unknown';
-      json(res, 500, { error: msg, code });
+      process.stderr.write(`[studio:error] ${code}: ${msg}\n`);
+      if (res.headersSent) {
+        if (!res.writableEnded) {
+          try {
+            res.write(`data: ${JSON.stringify({ type: 'error', message: msg, code })}\n\n`);
+            res.write(`data: ${JSON.stringify({ type: 'message_end', reason: 'error' })}\n\n`);
+          } catch {
+            /* client disconnected */
+          }
+          res.end();
+        }
+      } else {
+        json(res, 500, { error: msg, code });
+      }
     }
   });
 
@@ -1486,7 +1499,7 @@ async function receiveMultipart(
     const name = nameMatch[1];
     const fnMatch = headers.match(/filename="([^"]+)"/);
     if (fnMatch && fnMatch[1]) {
-      const filename = fnMatch[1];
+      const filename = Buffer.from(fnMatch[1], 'binary').toString('utf8');
       const tmpPath = join(tmpdir(), `hv-upload-${randomUUID().slice(0, 8)}-${filename}`);
       await mkdir(dirname(tmpPath), { recursive: true });
       await fs.writeFile(tmpPath, Buffer.from(bodyRaw, 'binary'));

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -24,6 +24,6 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@powerformer/vela-cli": "^0.0.10"
+    "@powerformer/vela-cli": "^0.0.6"
   }
 }

--- a/packages/runtime/src/detect.ts
+++ b/packages/runtime/src/detect.ts
@@ -8,8 +8,16 @@ const exec = promisify(execFile);
 
 async function which(bin: string): Promise<string | null> {
   try {
-    const { stdout } = await exec('which', [bin], { timeout: 2000 });
-    return stdout.trim() || null;
+    const command = process.platform === 'win32' ? 'where.exe' : 'which';
+    const { stdout } = await exec(command, [bin], { timeout: 2000 });
+    const matches = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (process.platform === 'win32') {
+      return matches.find((match) => /\.(exe|cmd|bat)$/i.test(match)) ?? matches[0] ?? null;
+    }
+    return matches[0] ?? null;
   } catch {
     return null;
   }
@@ -43,7 +51,7 @@ export async function resolveBin(def: AgentDef): Promise<string | null> {
 
 async function probeVersion(bin: string, args: string[]): Promise<string | null> {
   try {
-    const { stdout } = await exec(bin, args, { timeout: 5000 });
+    const { stdout } = await exec(bin, args, { timeout: 5000, shell: process.platform === 'win32' });
     return stdout.trim().split('\n')[0] ?? null;
   } catch {
     return null;

--- a/packages/runtime/src/spawn.ts
+++ b/packages/runtime/src/spawn.ts
@@ -1,6 +1,21 @@
 import { spawn as cpSpawn } from 'node:child_process';
 import type { AgentDef, AgentEvent, AgentInvokeContext, SpawnHandle } from './types.js';
 
+function stripWindowsProcessNoise(text: string): string {
+  // Windows helper commands sometimes leak localized "process terminated" lines
+  // through stdout. When they are decoded as UTF-8 they become mojibake and pollute
+  // the chat, but they are not agent content.
+  return text
+    .split(/\r?\n/)
+    .filter((line) => {
+      if (!line.trim()) return true;
+      if (/\bPID\s+\d+\b.*\bPID\s+\d+\b/i.test(line)) return false;
+      if (/^(SUCCESS|成功)[:：].*\bPID\s+\d+\b/i.test(line)) return false;
+      return true;
+    })
+    .join('\n');
+}
+
 /**
  * Spawn an agent CLI and stream events to the listener.
  * v0.1: only supports streamFormat='plain' fully (chunks emitted as text events).
@@ -75,6 +90,7 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
     cwd: context.cwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
   });
 
   if (def.promptViaStdin && child.stdin) {
@@ -86,7 +102,8 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
   let stderrBuf = '';
 
   child.stdout?.on('data', (chunk: Buffer) => {
-    const text = chunk.toString('utf8');
+    const text = stripWindowsProcessNoise(chunk.toString('utf8'));
+    if (!text) return;
     stdoutBuf += text;
     if (def.streamFormat === 'plain') {
       onEvent?.({ type: 'text', chunk: text });


### PR DESCRIPTION
This PR fixes several Windows-specific Studio runtime issues found while running the project locally.

Changes:
- Detect local agents on Windows with `where.exe` instead of `which`.
- Allow probing `.cmd` / `.exe` based CLIs such as Codex and Claude Code.
- Filter Windows process termination noise so PID/system messages do not pollute chat output.
- Preserve UTF-8 filenames in multipart uploads, including Chinese attachment names.
- Avoid crashing the Studio server when an SSE request errors after headers were already sent.
- Remove `chmod` from the CLI build script so the workspace builds on Windows.
- Use the currently published `@powerformer/vela-cli` version available on npm.

Verified locally on Windows:
- `pnpm install`
- `pnpm -r build`
- Studio agent scan detects Claude Code and Codex CLI
- Codex CLI message through Studio no longer emits PID noise
- Chinese filename upload is preserved