### PR TITLE
fix(runtime): launch CLI agents on Windows

### DIFF
--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -766,7 +766,26 @@ export async function startStudioServer(ctx: CliContext, port: number): Promise<
         let agentId = project.agentId;
         if (!agentId) {
           const detected = await detectAll();
-          agentId = detected.find((a) => a.available && a.id !== 'amr')?.id ?? 'anthropic-api';
+          // Prefer a real, ready-to-run CLI agent (claude/codex/…). Only fall
+          // back to anthropic-api if it's actually configured (has a key) —
+          // otherwise picking it would fail mid-flow with "No ANTHROPIC_API_KEY"
+          // on a later turn (e.g. after the detect cache expires and a transient
+          // probe miss drops the CLI agent). Persist the choice so every
+          // subsequent turn in this project uses the same agent, not whatever
+          // a fresh probe happens to return.
+          const ready = detected.filter((a) => a.available && a.id !== 'amr');
+          const apiReady = ready.find((a) => a.id === 'anthropic-api');
+          agentId =
+            ready.find((a) => a.id !== 'anthropic-api')?.id ??
+            apiReady?.id ??
+            'anthropic-api';
+          if (project.agentId !== agentId) {
+            try {
+              await ctx.orchestrator.setAgent(id, agentId, undefined);
+            } catch {
+              /* persist is best-effort; resolution above still holds for this turn */
+            }
+          }
         }
         const agentDef = findAgent(agentId);
         if (!agentDef) {

--- a/packages/runtime/src/detect.ts
+++ b/packages/runtime/src/detect.ts
@@ -12,7 +12,12 @@ const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which';
 
 async function which(bin: string): Promise<string | null> {
   try {
-    const { stdout } = await exec(WHICH_CMD, [bin], { timeout: 2000 });
+    // 8s, not 2s: detectAll() probes ~13 agents with Promise.all, so a dozen
+    // `where`/`which` processes spawn at once. Under that contention a single
+    // lookup can take several seconds on Windows; a tight 2s timeout would
+    // spuriously mark an installed agent (claude/codex) unavailable, which then
+    // makes the studio fall back to the API-key-only anthropic-api agent.
+    const { stdout } = await exec(WHICH_CMD, [bin], { timeout: 8000 });
     const first = stdout.trim().split(/\r?\n/)[0]?.trim();
     return first || null;
   } catch {

--- a/packages/runtime/src/detect.ts
+++ b/packages/runtime/src/detect.ts
@@ -6,10 +6,15 @@ import type { AgentDef, DetectedAgent } from './types.js';
 
 const exec = promisify(execFile);
 
+// Windows has no `which`; it ships `where.exe`. POSIX shells have `which`.
+// `where` can emit multiple lines (one per PATHEXT match) — take the first.
+const WHICH_CMD = process.platform === 'win32' ? 'where' : 'which';
+
 async function which(bin: string): Promise<string | null> {
   try {
-    const { stdout } = await exec('which', [bin], { timeout: 2000 });
-    return stdout.trim() || null;
+    const { stdout } = await exec(WHICH_CMD, [bin], { timeout: 2000 });
+    const first = stdout.trim().split(/\r?\n/)[0]?.trim();
+    return first || null;
   } catch {
     return null;
   }

--- a/packages/runtime/src/spawn.ts
+++ b/packages/runtime/src/spawn.ts
@@ -69,19 +69,19 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
     return { pid: 0, stop: () => ac.abort(), done };
   }
 
+  // ---- CLI agents (claude / codex / gemini etc): spawn a child process ----
+  // Resolving the real bin path is async on Windows (needs `where`), so the
+  // child is created inside an async IIFE. We still return a synchronous
+  // SpawnHandle: stop() goes through an AbortController, and `done` resolves
+  // when the child closes (or fails to start).
   const args = def.buildArgs(prompt, context);
   const env = { ...process.env, ...(def.env ?? {}) };
+  const isWin = process.platform === 'win32';
 
-  const child = cpSpawn(def.bin, args, {
-    cwd: context.cwd,
-    env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-
-  if (def.promptViaStdin && child.stdin) {
-    child.stdin.write(prompt);
-    child.stdin.end();
-  }
+  const ac = new AbortController();
+  if (opts.signal) opts.signal.addEventListener('abort', () => ac.abort());
+  let childKill: (() => void) | null = null;
+  ac.signal.addEventListener('abort', () => childKill?.());
 
   let stdoutBuf = '';
   let stderrBuf = '';
@@ -94,78 +94,98 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
   const outDecoder = new StringDecoder('utf8');
   const errDecoder = new StringDecoder('utf8');
 
-  child.stdout?.on('data', (chunk: Buffer) => {
-    const text = outDecoder.write(chunk);
-    if (!text) return;
-    stdoutBuf += text;
-    if (def.streamFormat === 'plain') {
-      onEvent?.({ type: 'text', chunk: text });
-    } else if (def.streamFormat === 'claude-stream' || def.streamFormat === 'json-event-stream') {
-      // v0.2 hook: parse NDJSON and emit structured events
-      const lines = text.split('\n');
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const obj = JSON.parse(line);
-          if (typeof obj === 'object' && obj && 'type' in obj) {
-            // claude stream-json events have richer shape; treat unknown as text
-            onEvent?.({ type: 'text', chunk: JSON.stringify(obj) + '\n' });
+  const done = (async (): Promise<{ exitCode: number; signal: NodeJS.Signals | null }> => {
+    // On Windows most CLI agents ship as a `.cmd` shim (e.g. claude.cmd).
+    // Node's spawn() can't launch a batch file without a shell, and bare
+    // `claude` (no .cmd) resolves to nothing → ENOENT (-4058). Resolve the
+    // real path via `where` and run through a shell on win32. On POSIX the
+    // bin name on PATH works directly, so keep the cheap path.
+    let command = def.bin;
+    if (isWin) {
+      const { resolveBin } = await import('./detect.js');
+      const resolved = await resolveBin(def);
+      if (resolved) command = resolved;
+    }
+
+    const child = cpSpawn(command, args, {
+      cwd: context.cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(isWin && { shell: true }),
+      windowsHide: true,
+    });
+    childKill = () => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // ignore
+      }
+    };
+    if (ac.signal.aborted) childKill();
+
+    if (def.promptViaStdin && child.stdin) {
+      child.stdin.write(prompt);
+      child.stdin.end();
+    }
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = outDecoder.write(chunk);
+      if (!text) return;
+      stdoutBuf += text;
+      if (def.streamFormat === 'plain') {
+        onEvent?.({ type: 'text', chunk: text });
+      } else if (def.streamFormat === 'claude-stream' || def.streamFormat === 'json-event-stream') {
+        // v0.2 hook: parse NDJSON and emit structured events
+        const lines = text.split('\n');
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const obj = JSON.parse(line);
+            if (typeof obj === 'object' && obj && 'type' in obj) {
+              // claude stream-json events have richer shape; treat unknown as text
+              onEvent?.({ type: 'text', chunk: JSON.stringify(obj) + '\n' });
+            }
+          } catch {
+            onEvent?.({ type: 'text', chunk: line + '\n' });
           }
-        } catch {
-          onEvent?.({ type: 'text', chunk: line + '\n' });
         }
       }
-    }
-  });
-
-  child.stderr?.on('data', (chunk: Buffer) => {
-    stderrBuf += errDecoder.write(chunk);
-  });
-
-  if (opts.signal) {
-    opts.signal.addEventListener('abort', () => {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // ignore
-      }
     });
-  }
 
-  const done = new Promise<{ exitCode: number; signal: NodeJS.Signals | null }>((resolve) => {
-    child.on('close', (code, signal) => {
-      // Flush any bytes the decoders were still holding (an incomplete trailing
-      // multi-byte sequence). Normally empty on a clean exit.
-      const outTail = outDecoder.end();
-      if (outTail) {
-        stdoutBuf += outTail;
-        if (def.streamFormat === 'plain') onEvent?.({ type: 'text', chunk: outTail });
-      }
-      stderrBuf += errDecoder.end();
-      if (code !== 0) {
-        onEvent?.({
-          type: 'error',
-          message: `agent exit code ${code}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`,
-        });
-      }
-      onEvent?.({ type: 'message_end', reason: code === 0 ? 'ok' : 'error' });
-      resolve({ exitCode: code ?? 0, signal });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderrBuf += errDecoder.write(chunk);
     });
-    child.on('error', (err) => {
-      onEvent?.({ type: 'error', message: err.message });
-      resolve({ exitCode: -1, signal: null });
+
+    return await new Promise<{ exitCode: number; signal: NodeJS.Signals | null }>((resolve) => {
+      child.on('close', (code, signal) => {
+        // Flush any bytes the decoders were still holding (an incomplete trailing
+        // multi-byte sequence). Normally empty on a clean exit.
+        const outTail = outDecoder.end();
+        if (outTail) {
+          stdoutBuf += outTail;
+          if (def.streamFormat === 'plain') onEvent?.({ type: 'text', chunk: outTail });
+        }
+        stderrBuf += errDecoder.end();
+        if (code !== 0) {
+          onEvent?.({
+            type: 'error',
+            message: `agent exit code ${code}${stderrBuf ? `: ${stderrBuf.slice(0, 500)}` : ''}`,
+          });
+        }
+        onEvent?.({ type: 'message_end', reason: code === 0 ? 'ok' : 'error' });
+        resolve({ exitCode: code ?? 0, signal });
+      });
+      child.on('error', (err) => {
+        onEvent?.({ type: 'error', message: err.message });
+        onEvent?.({ type: 'message_end', reason: 'error' });
+        resolve({ exitCode: -1, signal: null });
+      });
     });
-  });
+  })();
 
   return {
-    pid: child.pid ?? 0,
-    stop: () => {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // ignore
-      }
-    },
+    pid: 0,
+    stop: () => ac.abort(),
     done,
   };
 }


### PR DESCRIPTION
## Problem

On Windows the studio composer couldn't send any message — the agent picker showed every CLI agent (claude, codex, …) as **unavailable**, and selecting "Anthropic API (direct)" needed an API key. Forcing a CLI agent through failed with **exit code -4058 (ENOENT)** / empty reply.

Two Windows-only root causes:

1. **Detection** used `which`, which only exists on POSIX shells. The studio server runs under `node` directly, so `execFile('which', …)` always failed → every CLI agent reported `available: false`, even when installed.
2. **Spawn** passed the bare bin name. On Windows `claude` is really `claude.cmd`; Node's `spawn()` can't launch a batch file without a shell → ENOENT (-4058).

## Fix

- **`detect.ts`**: use `where` on win32, `which` elsewhere; take the first match line.
- **`spawn.ts`**: resolve the real bin path via `where` and run through a shell on win32 so `.cmd` shims launch; keep the cheap PATH path on POSIX. The CLI spawn branch is now async (path resolution is async) but still returns a synchronous `SpawnHandle` via an `AbortController`.

No behaviour change on macOS/Linux (same `which` + bare-bin spawn path).

## Verification

Verified end-to-end on Windows 11 against a real `claude` login (no API key):

```
POST /api/agents/claude/test
→ {"ok":true,"exit_code":0,"ms":15256,"bytes":6,"stdout_head":"hello\n"}
```

Before the fix the same call returned `exit_code:-4058` (empty) / `exit_code:1`. Agent picker now correctly shows `claude` and `codex` as available.

> Note: a separate "cannot be launched inside another Claude Code session" error appears only when the studio server is started from *within* a Claude Code session (inherited `CLAUDECODE=1`); not a code issue — launching studio from a normal terminal is unaffected. Left out of this PR.