### PR TITLE
fix(runtime): detect agent CLIs on Windows

### DIFF
--- a/packages/runtime/src/detect.ts
+++ b/packages/runtime/src/detect.ts
@@ -1,5 +1,7 @@
 import { execFile } from 'node:child_process';
 import { accessSync, constants } from 'node:fs';
+import { delimiter, isAbsolute, join } from 'node:path';
+import { platform } from 'node:os';
 import { promisify } from 'node:util';
 import { AGENT_DEFS } from './registry.js';
 import type { AgentDef, DetectedAgent } from './types.js';
@@ -7,12 +9,51 @@ import type { AgentDef, DetectedAgent } from './types.js';
 const exec = promisify(execFile);
 
 async function which(bin: string): Promise<string | null> {
+  const direct = resolveCommandSync(bin);
+  if (direct) return direct;
   try {
-    const { stdout } = await exec('which', [bin], { timeout: 2000 });
-    return stdout.trim() || null;
+    const cmd = platform() === 'win32' ? 'where.exe' : 'which';
+    const { stdout } = await exec(cmd, [bin], { timeout: 2000 });
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? null;
   } catch {
     return null;
   }
+}
+
+export function resolveCommandSync(bin: string): string | null {
+  try {
+    accessSync(bin, constants.X_OK);
+    return bin;
+  } catch {
+    if (isAbsolute(bin)) return null;
+  }
+
+  const pathEntries = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  const extensions =
+    platform() === 'win32'
+      ? (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+          .split(';')
+          .filter(Boolean)
+      : [''];
+  const candidates = platform() === 'win32' && /\.[^\\/]+$/.test(bin)
+    ? [bin]
+    : extensions.map((ext) => `${bin}${ext.toLowerCase()}`);
+
+  for (const dir of pathEntries) {
+    for (const candidate of candidates) {
+      const full = join(dir, candidate);
+      try {
+        accessSync(full, constants.X_OK);
+        return full;
+      } catch {
+        /* keep looking */
+      }
+    }
+  }
+  return null;
 }
 
 /** PATH → static binFallbacks → async resolveBinFallback (e.g. bundled npm pkg). */

--- a/packages/runtime/src/spawn.ts
+++ b/packages/runtime/src/spawn.ts
@@ -1,5 +1,6 @@
 import { spawn as cpSpawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
+import { resolveCommandSync } from './detect.js';
 import type { AgentDef, AgentEvent, AgentInvokeContext, SpawnHandle } from './types.js';
 
 /**
@@ -71,8 +72,9 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
 
   const args = def.buildArgs(prompt, context);
   const env = { ...process.env, ...(def.env ?? {}) };
+  const bin = resolveCommandSync(def.bin) ?? def.bin;
 
-  const child = cpSpawn(def.bin, args, {
+  const child = cpSpawn(bin, args, {
     cwd: context.cwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/runtime/src/spawn.ts
+++ b/packages/runtime/src/spawn.ts
@@ -1,7 +1,7 @@
 import { spawn as cpSpawn } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { platform } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, normalize } from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { resolveCommandSync } from './detect.js';
 import type { AgentDef, AgentEvent, AgentInvokeContext, SpawnHandle } from './types.js';
@@ -210,15 +210,35 @@ function commandForNpmShim(
     return null;
   }
 
-  const match = text.match(/"%dp0%\\node_modules\\([^"]+)"\s+%\*/i);
-  if (!match?.[1]) return null;
-
   const shimDir = dirname(bin);
+  const scriptPath = resolveNpmShimScript(text, shimDir);
+  if (!scriptPath || !existsSync(scriptPath)) return null;
+
   const bundledNode = join(shimDir, 'node.exe');
   const nodeBin = existsSync(bundledNode) ? bundledNode : (resolveCommandSync('node') ?? 'node');
-  const scriptPath = join(shimDir, 'node_modules', match[1]);
-  if (!existsSync(scriptPath)) return null;
   return { bin: nodeBin, args: [scriptPath, ...args] };
+}
+
+function resolveNpmShimScript(text: string, shimDir: string): string | null {
+  const dp0Vars = new Map<string, string>();
+  const setDp0Re = /^\s*set\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*%~dp0\s*$/gim;
+  for (const match of text.matchAll(setDp0Re)) {
+    if (match[1]) dp0Vars.set(match[1].toLowerCase(), shimDir);
+  }
+
+  const dp0ExecRe = /"%~dp0\\?([^"]*?node_modules\\[^"]+)"\s+%\*/gi;
+  for (const match of text.matchAll(dp0ExecRe)) {
+    if (match[1]) return normalize(join(shimDir, match[1]));
+  }
+
+  const varExecRe = /"%([A-Za-z_][A-Za-z0-9_]*)%\\?([^"]*?node_modules\\[^"]+)"\s+%\*/gi;
+  for (const match of text.matchAll(varExecRe)) {
+    const base = match[1] ? dp0Vars.get(match[1].toLowerCase()) : undefined;
+    const relative = match[2];
+    if (!base || !relative) continue;
+    return normalize(join(base, relative));
+  }
+  return null;
 }
 
 function quoteCmdArg(arg: string): string {

--- a/packages/runtime/src/spawn.ts
+++ b/packages/runtime/src/spawn.ts
@@ -1,4 +1,5 @@
 import { spawn as cpSpawn } from 'node:child_process';
+import { platform } from 'node:os';
 import { StringDecoder } from 'node:string_decoder';
 import { resolveCommandSync } from './detect.js';
 import type { AgentDef, AgentEvent, AgentInvokeContext, SpawnHandle } from './types.js';
@@ -73,11 +74,15 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
   const args = def.buildArgs(prompt, context);
   const env = { ...process.env, ...(def.env ?? {}) };
   const bin = resolveCommandSync(def.bin) ?? def.bin;
+  const command = commandForSpawn(bin, args);
 
-  const child = cpSpawn(bin, args, {
+  const child = cpSpawn(command.bin, command.args, {
     cwd: context.cwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    ...(command.windowsVerbatimArguments !== undefined && {
+      windowsVerbatimArguments: command.windowsVerbatimArguments,
+    }),
   });
 
   if (def.promptViaStdin && child.stdin) {
@@ -170,5 +175,27 @@ export function spawnAgent(opts: SpawnOptions): SpawnHandle {
     },
     done,
   };
+}
+
+function commandForSpawn(
+  bin: string,
+  args: string[],
+): { bin: string; args: string[]; windowsVerbatimArguments?: boolean } {
+  if (platform() !== 'win32' || !/\.(?:cmd|bat)$/i.test(bin)) {
+    return { bin, args };
+  }
+
+  const comspec = process.env.ComSpec || 'cmd.exe';
+  const commandLine = ['call', quoteCmdArg(bin), ...args.map(quoteCmdArg)].join(' ');
+  return {
+    bin: comspec,
+    args: ['/d', '/c', commandLine],
+    windowsVerbatimArguments: true,
+  };
+}
+
+function quoteCmdArg(arg: string): string {
+  if (arg.length === 0) return '""';
+  return `"${arg.replace(/"/g, '""')}"`;
 }
 

--- a/packages/runtime/src/spawn.ts
+++ b/packages/runtime/src/spawn.ts
@@ -1,5 +1,7 @@
 import { spawn as cpSpawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import { platform } from 'node:os';
+import { dirname, join } from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { resolveCommandSync } from './detect.js';
 import type { AgentDef, AgentEvent, AgentInvokeContext, SpawnHandle } from './types.js';
@@ -185,6 +187,9 @@ function commandForSpawn(
     return { bin, args };
   }
 
+  const npmShim = commandForNpmShim(bin, args);
+  if (npmShim) return npmShim;
+
   const comspec = process.env.ComSpec || 'cmd.exe';
   const commandLine = ['call', quoteCmdArg(bin), ...args.map(quoteCmdArg)].join(' ');
   return {
@@ -192,6 +197,28 @@ function commandForSpawn(
     args: ['/d', '/c', commandLine],
     windowsVerbatimArguments: true,
   };
+}
+
+function commandForNpmShim(
+  bin: string,
+  args: string[],
+): { bin: string; args: string[] } | null {
+  let text: string;
+  try {
+    text = readFileSync(bin, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const match = text.match(/"%dp0%\\node_modules\\([^"]+)"\s+%\*/i);
+  if (!match?.[1]) return null;
+
+  const shimDir = dirname(bin);
+  const bundledNode = join(shimDir, 'node.exe');
+  const nodeBin = existsSync(bundledNode) ? bundledNode : (resolveCommandSync('node') ?? 'node');
+  const scriptPath = join(shimDir, 'node_modules', match[1]);
+  if (!existsSync(scriptPath)) return null;
+  return { bin: nodeBin, args: [scriptPath, ...args] };
 }
 
 function quoteCmdArg(arg: string): string {

--- a/packages/runtime/test/spawn-windows-cmd-shim.test.ts
+++ b/packages/runtime/test/spawn-windows-cmd-shim.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnAgent } from '../dist/index.js';
@@ -46,6 +46,68 @@ test(
       const { exitCode } = await handle.done;
       assert.equal(exitCode, 0, error);
       assert.equal(collected, 'shim-ok');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  'Windows npm .cmd shims preserve percent argv through spawnAgent',
+  { skip: process.platform !== 'win32' },
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'hv-npm-cmd-shim-'));
+    const shim = join(dir, 'argv-agent.cmd');
+    const packageDir = join(dir, 'node_modules', 'argv-agent', 'bin');
+    const script = join(packageDir, 'argv-agent.js');
+    const node = process.execPath;
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      script,
+      'console.log(JSON.stringify(process.argv.slice(2)));\n',
+      'utf8',
+    );
+    await writeFile(
+      shim,
+      [
+        '@ECHO off',
+        'SETLOCAL',
+        'IF EXIST "%dp0%\\node.exe" (',
+        '  SET "_prog=%dp0%\\node.exe"',
+        ') ELSE (',
+        `  SET "_prog=${node}"`,
+        ')',
+        'endLocal & "%_prog%" "%dp0%\\node_modules\\argv-agent\\bin\\argv-agent.js" %*',
+        '',
+      ].join('\r\n'),
+      'utf8',
+    );
+
+    const argv = ['%USERPROFILE%', '100% done', 'bang!'];
+    const def: AgentDef = {
+      id: 'test-npm-cmd-shim',
+      name: 'test-npm-cmd-shim',
+      bin: shim,
+      versionArgs: ['--version'],
+      buildArgs: () => argv,
+      streamFormat: 'plain',
+    };
+
+    let collected = '';
+    let error = '';
+    try {
+      const handle = spawnAgent({
+        def,
+        prompt: '',
+        context: { cwd: dir },
+        onEvent: (ev) => {
+          if (ev.type === 'text') collected += ev.chunk;
+          if (ev.type === 'error') error += ev.message;
+        },
+      });
+      const { exitCode } = await handle.done;
+      assert.equal(exitCode, 0, error);
+      assert.deepEqual(JSON.parse(collected), argv);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/runtime/test/spawn-windows-cmd-shim.test.ts
+++ b/packages/runtime/test/spawn-windows-cmd-shim.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnAgent } from '../dist/index.js';
+import type { AgentDef } from '../dist/index.js';
+
+test(
+  'Windows .cmd shims launch through spawnAgent',
+  { skip: process.platform !== 'win32' },
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'hv-cmd-shim-'));
+    const shim = join(dir, 'echo-agent.cmd');
+    const script = join(dir, 'echo-agent.js');
+    const node = process.execPath;
+    await writeFile(script, 'process.stdin.pipe(process.stdout);\n', 'utf8');
+    await writeFile(
+      shim,
+      `@echo off\r\n"${node}" "${script}"\r\n`,
+      'utf8',
+    );
+
+    const def: AgentDef = {
+      id: 'test-cmd-shim',
+      name: 'test-cmd-shim',
+      bin: shim,
+      versionArgs: ['--version'],
+      buildArgs: () => [],
+      streamFormat: 'plain',
+      promptViaStdin: true,
+    };
+
+    let collected = '';
+    let error = '';
+    try {
+      const handle = spawnAgent({
+        def,
+        prompt: 'shim-ok',
+        context: { cwd: dir },
+        onEvent: (ev) => {
+          if (ev.type === 'text') collected += ev.chunk;
+          if (ev.type === 'error') error += ev.message;
+        },
+      });
+      const { exitCode } = await handle.done;
+      assert.equal(exitCode, 0, error);
+      assert.equal(collected, 'shim-ok');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/runtime/test/spawn-windows-cmd-shim.test.ts
+++ b/packages/runtime/test/spawn-windows-cmd-shim.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { spawnAgent } from '../dist/index.js';
 import type { AgentDef } from '../dist/index.js';
 
@@ -53,6 +53,64 @@ test(
 );
 
 test(
+  'Windows npm .cmd shims with %~dp0 parent paths preserve percent argv',
+  { skip: process.platform !== 'win32' },
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'hv-npm-parent-cmd-shim-'));
+    const binDir = join(dir, 'bin');
+    const shim = join(binDir, 'argv-agent.cmd');
+    const packageDir = join(dir, 'node_modules', 'argv-agent', 'bin');
+    const script = join(packageDir, 'argv-agent.js');
+    await mkdir(packageDir, { recursive: true });
+    await mkdir(dirname(shim), { recursive: true });
+    await writeFile(
+      script,
+      'console.log(JSON.stringify(process.argv.slice(2)));\n',
+      'utf8',
+    );
+    await writeFile(
+      shim,
+      [
+        '@ECHO off',
+        'SETLOCAL',
+        'endLocal & node "%~dp0\\..\\node_modules\\argv-agent\\bin\\argv-agent.js" %*',
+        '',
+      ].join('\r\n'),
+      'utf8',
+    );
+
+    const argv = ['%USERPROFILE%', '100% done'];
+    const def: AgentDef = {
+      id: 'test-npm-parent-cmd-shim',
+      name: 'test-npm-parent-cmd-shim',
+      bin: shim,
+      versionArgs: ['--version'],
+      buildArgs: () => argv,
+      streamFormat: 'plain',
+    };
+
+    let collected = '';
+    let error = '';
+    try {
+      const handle = spawnAgent({
+        def,
+        prompt: '',
+        context: { cwd: dir },
+        onEvent: (ev) => {
+          if (ev.type === 'text') collected += ev.chunk;
+          if (ev.type === 'error') error += ev.message;
+        },
+      });
+      const { exitCode } = await handle.done;
+      assert.equal(exitCode, 0, error);
+      assert.deepEqual(JSON.parse(collected), argv);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   'Windows npm .cmd shims preserve percent argv through spawnAgent',
   { skip: process.platform !== 'win32' },
   async () => {
@@ -71,13 +129,22 @@ test(
       shim,
       [
         '@ECHO off',
+        'GOTO start',
+        ':find_dp0',
+        'SET dp0=%~dp0',
+        'EXIT /b',
+        ':start',
         'SETLOCAL',
+        'CALL :find_dp0',
+        '',
         'IF EXIST "%dp0%\\node.exe" (',
         '  SET "_prog=%dp0%\\node.exe"',
         ') ELSE (',
-        `  SET "_prog=${node}"`,
+        '  SET "_prog=node"',
+        '  SET PATHEXT=%PATHEXT:;.JS;=;%',
         ')',
-        'endLocal & "%_prog%" "%dp0%\\node_modules\\argv-agent\\bin\\argv-agent.js" %*',
+        '',
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\argv-agent\\bin\\argv-agent.js" %*',
         '',
       ].join('\r\n'),
       'utf8',


### PR DESCRIPTION
## Summary

- resolve agent binaries on Windows via `where.exe` / `PATHEXT` instead of Unix-only `which`
- add a shared command resolver for child-agent spawning so npm `.cmd`/`.bat` shims such as `codex`, `claude`, `gemini`, and `opencode` work without `shell: true`
- keep non-Windows behavior on the existing `which` path

## Verification

- `pnpm --filter @html-video/runtime typecheck`
- `pnpm --filter @html-video/runtime test`
- `pnpm --filter @html-video/cli typecheck`
- direct runtime smoke on Windows confirmed `codex`, `claude`, `gemini`, `opencode`, and `copilot` are detected as available via their `.cmd`/`.bat` shims

## Notes

While testing the local Studio, I also hit an existing `ERR_HTTP_HEADERS_SENT` crash from an in-flight Studio message request. That appears unrelated to this runtime PATH fix and is intentionally not included here.