### PR TITLE
Fix features: Save project name on blur/Enter in top navbar 修复顶部导航栏内联重命名问题

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ auto-install-peers=true
 strict-peer-dependencies=false
 shamefully-hoist=false
 prefer-workspace-packages=true
+onnxruntime-node-install=skip

--- a/packages/project-studio/public/app.js
+++ b/packages/project-studio/public/app.js
@@ -633,9 +633,28 @@ function wireToolbar() {
   }
   const nameInput = document.getElementById('proj-name');
   if (nameInput) {
-    nameInput.onblur = () => {
-      if (state.selected) nameInput.value = state.selected.name;
-    };
+    nameInput.addEventListener('keydown', async (e) => {
+      if (e.key === 'Enter') { nameInput.blur(); }
+      if (e.key === 'Escape') { if (state.selected) nameInput.value = state.selected.name; nameInput.blur(); }
+    });
+    nameInput.addEventListener('blur', async () => {
+      if (!state.selected) return;
+      const trimmed = nameInput.value.trim();
+      if (!trimmed || trimmed === state.selected.name) { nameInput.value = state.selected.name; return; }
+      try {
+        await API.patchProject(state.selected.id, { name: trimmed });
+        state.selected.name = trimmed;
+        // Also update the name in state.projects so the sidebar renders the new title
+        const proj = state.projects.find((p) => p.id === state.selected.id);
+        if (proj) proj.name = trimmed;
+        renderSidebar();
+        renderFooter();
+        toast(t('sidebar.renamed') || 'Renamed');
+      } catch (e) {
+        nameInput.value = state.selected.name;
+        toast(`${e?.message ?? e}`, 'error');
+      }
+    });
   }
   const sidebarToggle = document.getElementById('btn-sidebar-toggle');
   if (sidebarToggle) {


### PR DESCRIPTION
The top-navbar project-name input only reset to the original value on blur — it never called API.patchProject. The sidebar three-dot Rename worked because it uses prompt() + API.patchProject.

Changes:
- Enter key or click any area outside the input box: SAVE
- Escape key: RESET to Original Name (cancel edit)

Additional Change:
- .npmrc: add onnxruntime-node-install=skip to skip CUDA GPU binary download from NuGet CDN (unnecessary for CPU-only users, and the CDN is often unreachable from certain network environments)

注意顶部导航栏的项目名称输入框，当我尝试 Rename 并确认后，本来修改的项目名又重置为原始值——因为它从未调用过 API.patchProject。侧边栏的三个点“重命名”功能之所以有效，是因为它使用了 prompt() + API.patchProject。

更改：
- Enter 键或点击输入框外其他区域：保存
- Esc 键：重置为原始名称（取消编辑）

附加修改：
- .npmrc：添加 onnxruntime-node-install=skip 以跳过从 NuGet CDN 下载 CUDA GPU 二进制文件（仅使用 CPU 的用户无需此操作，且某些网络环境下常无法访问该 CDN）