### PR TITLE
Remove chmod completely from build step

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
   "types": "./dist/index.d.ts",
   "files": ["dist", "README.md"],
   "scripts": {
-    "build": "tsc -p tsconfig.json && chmod +x dist/bin.js",
+    "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke": "node dist/smoke.js",
     "test": "npm run build && node --test --experimental-strip-types \"test/**/*.test.ts\""


### PR DESCRIPTION
Node/Pnpm already handles the permissions automatically in both Windows and Linux using the Shebang, no need to use chmod here

Tested both in windows and linux (debian)

Fixes (#27)