### PR TITLE
feat(amr): tag vela CLI with AMR_CLIENT_SOURCE=html_video

### DIFF
--- a/packages/runtime/src/defs/amr.ts
+++ b/packages/runtime/src/defs/amr.ts
@@ -92,6 +92,9 @@ export const amr: AgentDef = {
   // ACP stdio runtime: starts a private OpenCode server, talks JSON-RPC.
   buildArgs: () => ['agent', 'run', '--runtime', 'opencode'],
   streamFormat: 'acp-json-rpc',
+  // Identify html-video as the host so the vela CLI tags its command +
+  // model_request analytics with source=html_video (revenue attribution).
+  env: { AMR_CLIENT_SOURCE: 'html_video' },
   installUrl: 'https://open-design.ai',
   // AMR rejects session/prompt until a model is set. Default to deepseek-v4-flash
   // (the "Lower cost / Many models" official pick); overridable per-call later.


### PR DESCRIPTION
## 背景
配合 vela 的「按宿主产品区分模型调用收入」改动（powerformer/vela#270）。html-video 通过 `vela agent run --runtime opencode` 调 AMR 模型，本 PR 让 vela CLI 知道调用方是 html-video。

## 改动
- `packages/runtime/src/defs/amr.ts`：AMR agent def 新增 `env: { AMR_CLIENT_SOURCE: 'html_video' }`。

该 env 经 `spawn.ts` 的 ACP 路径（`def.env` → vela 子进程）传入；vela CLI 据此把 `cli_command` / `model_request` 事件标记 `source=html_video`（收入归因）。无需改 html-video 的网络层（AMR 调用是 stdio）。

## 测试
- `@html-video/runtime` typecheck 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)