### PR TITLE
chore(amr): bump bundled vela CLI to 0.0.15 (+ source-tagged install link)

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -25,6 +25,6 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@powerformer/vela-cli": "^0.0.10"
+    "@powerformer/vela-cli": "^0.0.15"
   }
 }

--- a/packages/runtime/src/defs/amr.ts
+++ b/packages/runtime/src/defs/amr.ts
@@ -95,7 +95,9 @@ export const amr: AgentDef = {
   // Identify html-video as the host so the vela CLI tags its command +
   // model_request analytics with source=html_video (revenue attribution).
   env: { AMR_CLIENT_SOURCE: 'html_video' },
-  installUrl: 'https://open-design.ai',
+  // AMR home; ?source=html_video lets vela's home page_view attribute the visit
+  // to html-video (same host dimension as the model-spend attribution above).
+  installUrl: 'https://open-design.ai/amr?source=html_video',
   // AMR rejects session/prompt until a model is set. Default to deepseek-v4-flash
   // (the "Lower cost / Many models" official pick); overridable per-call later.
   defaultModel: 'deepseek-v4-flash',


### PR DESCRIPTION
## 背景
vela CLI `0.0.15` 已发布（powerformer/vela#270），携带按宿主产品归因的逻辑：读取 `AMR_CLIENT_SOURCE` env、注入 `X-AMR-Client-Source` header、给 `cli_command` / `model_request` 打 `source=html_video`。

## 改动
- `packages/runtime/package.json`：`@powerformer/vela-cli` `^0.0.10` → `^0.0.15`。html-video 通过 `vela agent run --runtime opencode` 调 AMR，bundle 到新版后 `AMR_CLIENT_SOURCE=html_video`（#39 已合入）才真正生效。
- `defs/amr.ts`：`installUrl` 指向 `https://open-design.ai/amr?source=html_video`，让 vela 的首页 page_view 把访问归因到 html-video。

> 说明：installUrl 这处改动原本在 #39 的分支上，但 #39 合并时只带了 `AMR_CLIENT_SOURCE` 那个 commit，installUrl 没进 main，这里一并补上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)