### PR TITLE
chore(amr): bump bundled vela CLI to 0.0.16

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -25,6 +25,6 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@powerformer/vela-cli": "^0.0.15"
+    "@powerformer/vela-cli": "^0.0.16"
   }
 }


### PR DESCRIPTION
## Why

`packages/runtime` bundles a pinned `@powerformer/vela-cli`, currently `^0.0.15` — which (caret on a `0.0.x` version) resolves to exactly `0.0.15`. That predates [powerformer/vela#277](https://github.com/powerformer/vela/pull/277), which makes the vela ACP bridge forward OpenCode token usage on the `session/prompt` result. Without it, AMR runs report `token_count_source: "unknown"` because the host has no `result.usage` to read.

vela `0.0.16` (npm `@powerformer/vela-cli@0.0.16`, all platform packages published) ships that fix.

## What changed

- `packages/runtime/package.json`: `@powerformer/vela-cli` `^0.0.15` → `^0.0.16`.

`pnpm-lock.yaml` is gitignored here, so the bump is the spec change only — a fresh `pnpm install` resolves `0.0.16`. Follows #40 (the `0.0.15` bump).

## Validation

- `@powerformer/vela-cli@0.0.16` + all platform packages confirmed published on npm.