### PR TITLE
feat(footage): RFC-11 Phase-0 — edit real footage as text (transcribe → select → cut)

### DIFF
--- a/packages/adapter-whisper/README.md
+++ b/packages/adapter-whisper/README.md
@@ -1,0 +1,42 @@
+# @html-video/adapter-whisper
+
+On-device, word-level transcription for the html-video **footage-edit** pipeline
+(RFC-11). The default ingest back-end: it turns a raw take into a time-coded
+transcript locally via [whisper.cpp](https://github.com/ggml-org/whisper.cpp) —
+no upload, no per-use fee.
+
+It implements `SourceAdapter` from `@html-video/core`, the ingest-side
+counterpart to `EngineAdapter`. Cloud ASR services can implement the same
+interface and expose a non-free `licensing`, so an agent can prefer this local
+adapter when privacy or cost matters.
+
+## Requirements
+
+| Tool | Install |
+|---|---|
+| ffmpeg | `brew install ffmpeg` |
+| whisper.cpp | `brew install whisper-cpp` (provides `whisper-cli`) |
+| a ggml model | download e.g. `ggml-base.en.bin` from [Hugging Face](https://huggingface.co/ggerganov/whisper.cpp) |
+
+```bash
+export HTMLVIDEO_WHISPER_MODEL=/path/to/ggml-base.en.bin
+# optional: export HTMLVIDEO_WHISPER_BIN=whisper-cli
+```
+
+## Usage
+
+```ts
+import { WhisperLocalAdapter } from '@html-video/adapter-whisper';
+import { SourceRegistry } from '@html-video/core';
+
+const sources = new SourceRegistry();
+sources.register(new WhisperLocalAdapter());
+
+const transcript = await sources
+  .get('whisper-local')
+  .transcribe(asset, { workDir: '/tmp/hv-work' });
+// transcript.words: [{ word: "Hey", start: 0.04, end: 0.22 }, …]
+```
+
+> Note: whisper mis-spells proper nouns (e.g. "Thariq" → "Theric") but the
+> **timestamps stay accurate**, which is all the cut points need.

--- a/packages/adapter-whisper/package.json
+++ b/packages/adapter-whisper/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@html-video/adapter-whisper",
+  "version": "0.1.0",
+  "description": "Whisper source adapter for html-video (RFC-11) — on-device, word-level transcription of raw takes via whisper.cpp. The default ingest back-end for the footage-edit pipeline: local, free, no upload.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@html-video/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/adapter-whisper/src/index.ts
+++ b/packages/adapter-whisper/src/index.ts
@@ -1,0 +1,130 @@
+/**
+ * @html-video/adapter-whisper — RFC-11 source adapter (whisper.cpp, local).
+ *
+ * Transcribes a raw take into a word-level {@link Transcript} entirely on the
+ * user's machine: ffmpeg extracts 16 kHz mono PCM, then `whisper-cli`
+ * (whisper.cpp) emits per-word segments which we parse into {word, start, end}.
+ * No upload, no per-use fee — the default ingest back-end. Cloud ASR adapters
+ * can implement the same {@link SourceAdapter} interface and expose a non-free
+ * `licensing` so an agent can avoid them when privacy / cost matters.
+ *
+ * Tooling (both surfaced with a friendly hint if missing):
+ *   - ffmpeg        — `brew install ffmpeg`
+ *   - whisper-cli   — `brew install whisper-cpp`  (binary configurable)
+ *   - a ggml model  — set HTMLVIDEO_WHISPER_MODEL=/path/to/ggml-base.en.bin
+ */
+import { HtmlVideoError } from '@html-video/core';
+import type { Asset, RenderContext, SourceAdapter, Transcript } from '@html-video/core';
+
+/** Override the whisper.cpp binary (default `whisper-cli`). */
+const WHISPER_BIN = process.env.HTMLVIDEO_WHISPER_BIN || 'whisper-cli';
+/** Override the ggml model path (no default — set the env var or pass in opts). */
+const MODEL_ENV = 'HTMLVIDEO_WHISPER_MODEL';
+
+export interface WhisperAdapterOptions {
+  /** Absolute path to a ggml model. Falls back to $HTMLVIDEO_WHISPER_MODEL. */
+  modelPath?: string;
+  /** Whisper language ('en', 'auto', …). Default 'auto'. */
+  language?: string;
+}
+
+export class WhisperLocalAdapter implements SourceAdapter {
+  readonly id = 'whisper-local';
+  readonly name = 'Whisper (whisper.cpp, local)';
+  readonly capabilities = {
+    local: true,
+    wordTimestamps: true,
+    languages: 'auto' as const,
+    licensing: 'free-osi' as const,
+  };
+
+  constructor(private opts: WhisperAdapterOptions = {}) {}
+
+  private modelPath(): string {
+    const m = this.opts.modelPath || process.env[MODEL_ENV];
+    if (!m) {
+      throw new HtmlVideoError(
+        'invalid-input',
+        `No whisper model configured. Download one (e.g. ggml-base.en.bin from ` +
+          `https://huggingface.co/ggerganov/whisper.cpp) and set ${MODEL_ENV}=/path/to/model.bin`,
+      );
+    }
+    return m;
+  }
+
+  async transcribe(asset: Asset, ctx: RenderContext): Promise<Transcript> {
+    if (!asset.path) {
+      throw new HtmlVideoError('invalid-input', `Asset "${asset.id}" has no file path to transcribe`);
+    }
+    const { join } = await import('node:path');
+    const { readFile, mkdir } = await import('node:fs/promises');
+
+    const model = this.modelPath();
+    const work = ctx.workDir;
+    await mkdir(work, { recursive: true });
+    const wav = join(work, `${asset.id}.wav`);
+    const prefix = join(work, `${asset.id}.transcript`);
+
+    // 1. extract 16 kHz mono PCM (whisper.cpp's expected input)
+    await run(
+      'ffmpeg',
+      ['-y', '-i', asset.path, '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le', wav, '-loglevel', 'error'],
+      'ffmpeg (wav extract)',
+      'ffmpeg not found on PATH. Install with `brew install ffmpeg`.',
+    );
+
+    // 2. word-level transcription: -ml 1 (one token/segment) + -sow (split on word)
+    const args = ['-m', model, '-f', wav, '-ml', '1', '-sow', '-oj', '-of', prefix];
+    const lang = this.opts.language;
+    if (lang && lang !== 'auto') args.push('-l', lang);
+    await run(
+      WHISPER_BIN,
+      args,
+      'whisper-cli',
+      `${WHISPER_BIN} not found on PATH. Install with \`brew install whisper-cpp\` (or set HTMLVIDEO_WHISPER_BIN).`,
+    );
+
+    // 3. parse whisper.cpp JSON → word list
+    const raw = await readFile(`${prefix}.json`, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      transcription?: { text: string; offsets: { from: number; to: number } }[];
+      result?: { language?: string };
+    };
+    const words = (parsed.transcription ?? [])
+      .filter((s) => s.text.replace(/[^a-zA-Z]/g, '').length > 0)
+      .map((s) => ({
+        word: s.text.trim(),
+        start: s.offsets.from / 1000,
+        end: s.offsets.to / 1000,
+      }));
+
+    return {
+      clipAssetId: asset.id,
+      words,
+      language: parsed.result?.language,
+      source: this.id,
+    };
+  }
+}
+
+/** Default-configured instance (reads model path from $HTMLVIDEO_WHISPER_MODEL). */
+const whisperLocal = new WhisperLocalAdapter();
+export default whisperLocal;
+
+async function run(bin: string, args: string[], label: string, missingHint: string): Promise<void> {
+  const { spawn } = await import('node:child_process');
+  await new Promise<void>((resolveFn, reject) => {
+    const proc = spawn(bin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    proc.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString('utf8');
+    });
+    proc.on('error', (err: NodeJS.ErrnoException) => {
+      reject(new HtmlVideoError(err.code === 'ENOENT' ? 'invalid-input' : 'render-failed', err.code === 'ENOENT' ? missingHint : String(err)));
+    });
+    proc.on('exit', (code: number | null) => {
+      if (code === 0) resolveFn();
+      else reject(new HtmlVideoError('render-failed', `${label} exited with code ${code}: ${stderr.slice(-1500)}`));
+    });
+  });
+}

--- a/packages/adapter-whisper/tsconfig.json
+++ b/packages/adapter-whisper/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "@html-video/core": "workspace:*",
     "@html-video/adapter-hyperframes": "workspace:*",
     "@html-video/adapter-remotion": "workspace:*",
+    "@html-video/adapter-whisper": "workspace:*",
     "@html-video/project-studio": "workspace:*",
     "@html-video/runtime": "workspace:*",
     "cac": "^6.7.14"

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -18,6 +18,7 @@ import {
   projectPreview,
   projectRender,
 } from './commands/project.js';
+import { footageEdit } from './commands/footage.js';
 import { startStudioServer } from './studio-server.js';
 
 // cac is a CJS default export; ESM interop sometimes wraps it in `.default`
@@ -184,6 +185,30 @@ cli
     await projectRender(ctx, id, {
       output: opts.output,
       streamProgress: !!opts.streamProgress,
+    });
+  });
+
+// ====== Footage edit (RFC-11: edit real takes as text) ======
+
+cli
+  .command('footage-edit', 'Edit raw takes into a cut: transcribe → select → cut → verify')
+  .option('--takes <dir>', 'Directory of take video files')
+  .option('--scenes <file>', 'Scenes JSON (SceneSpec[]); default = one scene per take')
+  .option('--out <file>', 'Output MP4 path (default: <work>/final.mp4)')
+  .option('--work <dir>', 'Work dir for transcripts/cuts (default: <takes>/../hv-footage-work)')
+  .option('--model <path>', 'Whisper ggml model (default: $HTMLVIDEO_WHISPER_MODEL)')
+  .option('--source <id>', 'Source adapter id', { default: 'whisper-local' })
+  .action(async (opts: any) => {
+    setJsonMode(!!opts.json);
+    if (!opts.takes) return fail('invalid-input', '--takes <dir> is required');
+    const ctx = await bootstrap({ cwd: opts.cwd });
+    await footageEdit(ctx, {
+      takes: opts.takes,
+      scenes: opts.scenes,
+      out: opts.out,
+      work: opts.work,
+      model: opts.model,
+      source: opts.source,
     });
   });
 

--- a/packages/cli/src/commands/footage.ts
+++ b/packages/cli/src/commands/footage.ts
@@ -1,0 +1,140 @@
+/**
+ * RFC-11 footage-edit command: takes → transcribe → select → EDL → cut → concat
+ * → re-transcribe verify. The whole "edit is text" loop, headless.
+ */
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import {
+  buildFootageGraph,
+  concatClips,
+  cutClip,
+  fillersIn,
+  type Asset,
+  type SceneSpec,
+  type Transcript,
+} from '@html-video/core';
+import type { FootageNode } from '@html-video/content-graph';
+import type { CliContext } from '../context.js';
+import { fail, ok, progress } from '../output.js';
+
+const VIDEO_EXT = new Set(['.mp4', '.mov', '.m4v', '.mkv', '.webm', '.avi']);
+
+export interface FootageEditOptions {
+  takes: string;
+  scenes?: string;
+  out?: string;
+  work?: string;
+  model?: string;
+  source?: string;
+}
+
+export async function footageEdit(ctx: CliContext, opts: FootageEditOptions): Promise<void> {
+  const takesDir = resolve(opts.takes);
+  if (!existsSync(takesDir)) return fail('invalid-input', `takes dir not found: ${takesDir}`);
+
+  // discover takes → assets (id = filename without extension)
+  const files = (await readdir(takesDir))
+    .filter((f) => VIDEO_EXT.has(extname(f).toLowerCase()))
+    .sort();
+  if (files.length === 0) return fail('invalid-input', `no video files in ${takesDir}`);
+  const assets: Record<string, Asset> = {};
+  for (const f of files) {
+    const id = f.slice(0, f.length - extname(f).length);
+    assets[id] = {
+      id,
+      type: 'video',
+      path: join(takesDir, f),
+      metadata: { filename: f },
+      userTags: [],
+    };
+  }
+
+  // scenes: explicit spec, or one scene per take in filename order
+  let scenes: SceneSpec[];
+  if (opts.scenes) {
+    const raw = await readFile(resolve(opts.scenes), 'utf8');
+    scenes = JSON.parse(raw) as SceneSpec[];
+    const missing = scenes.flatMap((s) => s.takes).filter((t) => !assets[t]);
+    if (missing.length) return fail('invalid-input', `scenes reference unknown takes: ${[...new Set(missing)].join(', ')}`);
+  } else {
+    scenes = Object.keys(assets).map((id, i) => ({ scene: i + 1, title: id, takes: [id] }));
+  }
+
+  const work = resolve(opts.work ?? join(takesDir, '..', 'hv-footage-work'));
+  await mkdir(work, { recursive: true });
+  const outPath = resolve(opts.out ?? join(work, 'final.mp4'));
+  if (opts.model) process.env.HTMLVIDEO_WHISPER_MODEL = resolve(opts.model);
+
+  const source = ctx.sources.get(opts.source ?? 'whisper-local');
+
+  // 1. transcribe every candidate take
+  const transcripts: Record<string, Transcript> = {};
+  const allTakes = [...new Set(scenes.flatMap((s) => s.takes))];
+  for (let i = 0; i < allTakes.length; i++) {
+    const id = allTakes[i]!;
+    progress('transcribe', Math.round((i / allTakes.length) * 100), { take: id });
+    try {
+      const t = await source.transcribe(assets[id]!, { workDir: work });
+      transcripts[id] = t;
+      await writeFile(join(work, `${id}.transcript.json`), JSON.stringify(t, null, 2));
+    } catch (err) {
+      return fail('render-failed', `transcribe ${id} failed: ${(err as Error).message}`);
+    }
+  }
+
+  // 2. select best take per scene → EDL graph
+  progress('select', 100, {});
+  const graph = buildFootageGraph(scenes, transcripts);
+  const edlPath = join(work, 'final-edit.json');
+  await writeFile(edlPath, JSON.stringify(graph, null, 2));
+  const nodes = graph.nodes as FootageNode[];
+
+  // 3. frame-accurate cut each pick, then concat-filter
+  const segDir = join(work, 'cuts');
+  await mkdir(segDir, { recursive: true });
+  const segs: string[] = [];
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i]!;
+    progress('cut', Math.round((i / nodes.length) * 100), { scene: n.id, take: n.clipAssetId });
+    const seg = join(segDir, `${n.id}.mp4`);
+    await cutClip(assets[n.clipAssetId]!.path!, n.in, n.out, seg);
+    segs.push(seg);
+  }
+  progress('concat', 100, {});
+  await concatClips(segs, outPath);
+
+  // 4. re-transcribe the cut and self-check (deck's "zero ums" verification)
+  progress('verify', 100, {});
+  let verify: { transcript: string; fillers: string[] } | { error: string };
+  try {
+    const finalT = await source.transcribe(
+      { id: '_final', type: 'video', path: outPath, metadata: {}, userTags: [] },
+      { workDir: work },
+    );
+    verify = {
+      transcript: finalT.words.map((w) => w.word.trim()).join(' '),
+      fillers: fillersIn(finalT.words),
+    };
+  } catch (err) {
+    verify = { error: (err as Error).message };
+  }
+
+  ok({
+    out: outPath,
+    edl: edlPath,
+    work,
+    takes: allTakes.length,
+    scenes: scenes.length,
+    picks: nodes.map((n) => ({
+      scene: n.id,
+      pick: n.clipAssetId,
+      in: n.in,
+      out: n.out,
+      firstWords: n.firstWords,
+      rationale: n.selectionRationale,
+    })),
+    verify,
+    clean: 'fillers' in verify ? verify.fillers.length === 0 : false,
+  });
+}

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -10,15 +10,18 @@ import {
   EngineRegistry,
   ProjectOrchestrator,
   ProjectStore,
+  SourceRegistry,
   TemplateRegistry,
 } from '@html-video/core';
 import hfAdapter from '@html-video/adapter-hyperframes';
 import remotionAdapter, { remotionInstalled } from '@html-video/adapter-remotion';
+import whisperAdapter from '@html-video/adapter-whisper';
 import { MediaConfigStore } from './media-config.js';
 
 export interface CliContext {
   projectRoot: string;
   engines: EngineRegistry;
+  sources: SourceRegistry;
   templates: TemplateRegistry;
   projects: ProjectStore;
   assets: AssetStore;
@@ -63,6 +66,11 @@ export async function bootstrap(opts: { cwd?: string } = {}): Promise<CliContext
     engines.register(remotionAdapter);
   }
 
+  // RFC-11: footage ingest. whisper-local registers unconditionally; it throws
+  // a friendly hint at transcribe time if whisper-cli / model are missing.
+  const sources = new SourceRegistry();
+  sources.register(whisperAdapter);
+
   const templates = new TemplateRegistry();
   const templatesDir = findTemplatesDir(projectRoot);
   await templates.scan(templatesDir);
@@ -80,5 +88,5 @@ export async function bootstrap(opts: { cwd?: string } = {}): Promise<CliContext
 
   const mediaConfig = new MediaConfigStore(projectRoot);
 
-  return { projectRoot, engines, templates, projects, assets, orchestrator, templatesDir, mediaConfig };
+  return { projectRoot, engines, sources, templates, projects, assets, orchestrator, templatesDir, mediaConfig };
 }

--- a/packages/content-graph/src/index.ts
+++ b/packages/content-graph/src/index.ts
@@ -8,7 +8,7 @@
  * #4 graph-then-sort) for the design rationale.
  */
 
-export type NodeKind = 'entity' | 'data' | 'text';
+export type NodeKind = 'entity' | 'data' | 'text' | 'footage';
 
 export interface BaseNode {
   /** Stable id; agent picks readable strings like "intro_logo", "stat_users". */
@@ -56,7 +56,33 @@ export interface TextNode extends BaseNode {
   text: string;
 }
 
-export type Node = EntityNode | DataNode | TextNode;
+/**
+ * RFC-11: a segment cut from real footage. Unlike entity/data/text nodes (which
+ * are *synthesised* into HTML frames), a footage node points at a take in the
+ * project's assets and an in/out range to cut from it. A content-graph may mix
+ * footage and synthesised nodes — that is how "talking-head + data overlay"
+ * edits are expressed in a single timeline.
+ *
+ * The footage node is also the unit of the EDL ("edit decision list"): it
+ * carries the takes that were *considered* and the written reasoning for the
+ * pick, so the edit stays diffable text the agent can read and re-decide.
+ */
+export interface FootageNode extends BaseNode {
+  kind: 'footage';
+  /** asset.id of the chosen take (type 'video'). */
+  clipAssetId: string;
+  /** Frame-accurate in/out points in the source clip, seconds. */
+  in: number;
+  out: number;
+  /** First few spoken words of the kept segment — human-readable sanity check. */
+  firstWords?: string;
+  /** asset.ids of the other takes considered for this scene (the EDL trail). */
+  candidateClipAssetIds?: string[];
+  /** Why this take was picked over the others — the "edit is text" rationale. */
+  selectionRationale?: string;
+}
+
+export type Node = EntityNode | DataNode | TextNode | FootageNode;
 
 export type EdgeKind = 'sequence' | 'contrast' | 'dependency';
 
@@ -112,7 +138,8 @@ export interface GraphValidationError {
     | 'self-edge'
     | 'cycle'
     | 'empty-graph'
-    | 'invalid-kind';
+    | 'invalid-kind'
+    | 'invalid-footage';
   message: string;
   /** Offending node or edge for UI highlighting. */
   ref?: string;
@@ -148,12 +175,29 @@ export function validate(graph: ContentGraph): GraphValidationResult {
     }
     ids.add(n.id);
     const kind = (n as { kind: string }).kind;
-    if (kind !== 'entity' && kind !== 'data' && kind !== 'text') {
+    if (kind !== 'entity' && kind !== 'data' && kind !== 'text' && kind !== 'footage') {
       errors.push({
         code: 'invalid-kind',
         message: `Node "${(n as { id: string }).id}" has unknown kind "${kind}"`,
         ref: (n as { id: string }).id,
       });
+    }
+    if (kind === 'footage') {
+      const f = n as FootageNode;
+      if (!f.clipAssetId) {
+        errors.push({
+          code: 'invalid-footage',
+          message: `Footage node "${f.id}" is missing clipAssetId`,
+          ref: f.id,
+        });
+      }
+      if (!(f.out > f.in) || f.in < 0) {
+        errors.push({
+          code: 'invalid-footage',
+          message: `Footage node "${f.id}" has an invalid in/out range (${f.in} → ${f.out})`,
+          ref: f.id,
+        });
+      }
     }
   }
 
@@ -345,7 +389,12 @@ export function totalDurationSec(graph: ContentGraph): number {
   let total = 0;
   for (const id of order) {
     const n = getNode(graph, id);
-    total += n?.durationSec ?? DEFAULT_FRAME_DURATION_SEC;
+    if (n?.kind === 'footage') {
+      // A footage node plays for its cut length; durationSec, if set, overrides.
+      total += n.durationSec ?? (n as FootageNode).out - (n as FootageNode).in;
+    } else {
+      total += n?.durationSec ?? DEFAULT_FRAME_DURATION_SEC;
+    }
   }
   return total;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test test/"
+    "test": "node --test \"test/**/*.test.mjs\""
   },
   "dependencies": {
     "@html-video/content-graph": "workspace:*",

--- a/packages/core/src/footage.ts
+++ b/packages/core/src/footage.ts
@@ -1,0 +1,261 @@
+/**
+ * @html-video/core — RFC-11 footage edit primitives.
+ *
+ * The "edit is text" pipeline back-end: turn word-level transcripts into an EDL
+ * (a content-graph of footage nodes, each with the takes considered and the
+ * written reason for the pick), then frame-accurately cut and join the picks
+ * with ffmpeg.
+ *
+ * Pure logic (selection / EDL building) is dependency-free and unit-tested;
+ * the ffmpeg ops shell out and surface the same friendly missing-binary hint
+ * as the rest of core.
+ */
+import type { ContentGraph, Edge, FootageNode } from '@html-video/content-graph';
+import type { Transcript, TranscriptWord } from './types/index.js';
+import { HtmlVideoError } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Filler detection
+// ---------------------------------------------------------------------------
+
+/** Disfluencies a clean take should not contain. Matched on normalised tokens. */
+export const FILLER_WORDS = new Set([
+  'um', 'uh', 'ah', 'er', 'erm', 'hmm', 'uhh', 'umm', 'mm', 'eh',
+]);
+
+/** Lowercase + strip everything but a–z, so `"Ah!"` / `um,` still match. */
+export function normalizeWord(word: string): string {
+  return word.toLowerCase().replace(/[^a-z]/g, '');
+}
+
+/** The filler tokens present in a word list (verbatim, for reporting). */
+export function fillersIn(words: TranscriptWord[]): string[] {
+  return words.filter((w) => FILLER_WORDS.has(normalizeWord(w.word))).map((w) => w.word);
+}
+
+// ---------------------------------------------------------------------------
+// Take selection → EDL
+// ---------------------------------------------------------------------------
+
+/** A scene and its candidate takes, in shoot order (best is usually last). */
+export interface SceneSpec {
+  /** Stable scene id used as the footage node id (e.g. 1 or "intro"). */
+  scene: string | number;
+  title: string;
+  /** Candidate take asset ids, in the order they were shot. */
+  takes: string[];
+  /** A leading warm-up phrase to cut from the kept take ("hey everyone"). */
+  warmup?: string;
+}
+
+export interface SelectOptions {
+  /** Seconds to nudge the cut-in earlier, into the silent gap. Default 0.05. */
+  lead?: number;
+  /** Seconds of tail to keep after the last word. Default 0.15. */
+  tail?: number;
+}
+
+function endsSentence(word: string): boolean {
+  return /[.!?]["')\]]?$/.test(word.trim());
+}
+
+/**
+ * Pick the best take for one scene and return it as a footage node (the EDL
+ * entry). Heuristic mirrors how editors triage口播 takes: zero fillers and a
+ * complete ending win; ties break toward the later take. The chosen take's
+ * leading warm-up phrase is trimmed by starting the cut at the first content
+ * word after it. Every rejected take and the reason is written into the node.
+ */
+export function selectTake(
+  scene: SceneSpec,
+  transcripts: Record<string, Transcript>,
+  opts: SelectOptions = {},
+): FootageNode {
+  const lead = opts.lead ?? 0.05;
+  const tail = opts.tail ?? 0.15;
+  const cand = scene.takes;
+  if (cand.length === 0) {
+    throw new HtmlVideoError('invalid-input', `Scene "${scene.scene}" has no candidate takes`);
+  }
+
+  const scored = cand.map((clip, i) => {
+    const words = transcripts[clip]?.words ?? [];
+    const fillers = fillersIn(words);
+    const complete = words.length > 0 && endsSentence(words[words.length - 1]!.word);
+    // later takes get a small positional tiebreak (best take usually last)
+    const score = (fillers.length ? -10 * fillers.length : 0) + (complete ? 5 : 0) + i;
+    return { clip, i, words, fillers, complete, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  const best = scored[0]!;
+  const words = best.words;
+  if (words.length === 0) {
+    throw new HtmlVideoError(
+      'invalid-input',
+      `No usable transcript for any take in scene "${scene.scene}" (picked ${best.clip})`,
+    );
+  }
+
+  // cut-in: skip a leading warm-up phrase if present
+  let inIdx = 0;
+  if (scene.warmup) {
+    const norm = words.map((w) => normalizeWord(w.word));
+    const phrase = scene.warmup.split(/\s+/).map(normalizeWord).filter(Boolean);
+    for (let j = 0; j + phrase.length <= norm.length; j++) {
+      if (phrase.every((p, k) => norm[j + k] === p)) {
+        inIdx = j + phrase.length;
+        break;
+      }
+    }
+  }
+  const tIn = Math.max(0, words[inIdx]!.start - lead);
+  const tOut = words[words.length - 1]!.end + tail;
+  const firstWords = words
+    .slice(inIdx, inIdx + 5)
+    .map((w) => w.word.trim())
+    .join(' ');
+
+  const dropped = scored
+    .filter((s) => s.clip !== best.clip)
+    .map((s) =>
+      s.fillers.length
+        ? `${s.clip} dropped (fillers: ${s.fillers.join(', ')})`
+        : !s.complete
+          ? `${s.clip} dropped (incomplete take)`
+          : `${s.clip} dropped (earlier alt take)`,
+    );
+  let rationale = `${best.clip} is the cleanest complete take (${
+    best.fillers.length ? `${best.fillers.length} fillers` : 'zero fillers'
+  }).`;
+  if (dropped.length) rationale += ` ${dropped.join('; ')}.`;
+  if (scene.warmup && inIdx > 0) {
+    rationale += ` Warm-up "${scene.warmup}" cut: cut-in at ${tIn.toFixed(2)}s in the silent gap.`;
+  }
+
+  return {
+    kind: 'footage',
+    id: `scene${scene.scene}`,
+    label: scene.title,
+    clipAssetId: best.clip,
+    candidateClipAssetIds: cand,
+    in: round3(tIn),
+    out: round3(tOut),
+    firstWords,
+    selectionRationale: rationale,
+  };
+}
+
+/**
+ * Build a complete EDL content-graph: one footage node per scene, joined by
+ * sequence edges in scene order. Mixes cleanly with synthesised nodes later.
+ */
+export function buildFootageGraph(
+  scenes: SceneSpec[],
+  transcripts: Record<string, Transcript>,
+  opts: SelectOptions = {},
+): ContentGraph {
+  const nodes = scenes.map((s) => selectTake(s, transcripts, opts));
+  const edges: Edge[] = [];
+  for (let i = 0; i < nodes.length - 1; i++) {
+    edges.push({ from: nodes[i]!.id, to: nodes[i + 1]!.id, kind: 'sequence' });
+  }
+  return { schemaVersion: 1, intent: 'other', nodes, edges };
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+// ---------------------------------------------------------------------------
+// ffmpeg ops
+// ---------------------------------------------------------------------------
+
+async function runFfmpeg(args: string[], label: string): Promise<void> {
+  const { spawn } = await import('node:child_process');
+  await new Promise<void>((resolveFn, reject) => {
+    const proc = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderr = '';
+    proc.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString('utf8');
+    });
+    proc.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') {
+        reject(
+          new HtmlVideoError(
+            'render-failed',
+            'ffmpeg not found on PATH. Install with `brew install ffmpeg` (macOS) or your platform equivalent.',
+          ),
+        );
+      } else {
+        reject(err);
+      }
+    });
+    proc.on('exit', (code: number | null) => {
+      if (code === 0) resolveFn();
+      else
+        reject(
+          new HtmlVideoError(
+            'render-failed',
+            `ffmpeg ${label} exited with code ${code}: ${stderr.slice(-2000)}`,
+          ),
+        );
+    });
+  });
+}
+
+/**
+ * Frame-accurate cut of [inSec, outSec] from a source clip. Decodes from the
+ * start and trims with -ss/-to (re-encode) so the cut lands on the right frame
+ * rather than the nearest keyframe.
+ */
+export async function cutClip(
+  srcPath: string,
+  inSec: number,
+  outSec: number,
+  outPath: string,
+): Promise<void> {
+  if (!(outSec > inSec)) {
+    throw new HtmlVideoError('invalid-input', `cutClip: out (${outSec}) must exceed in (${inSec})`);
+  }
+  await runFfmpeg(
+    [
+      '-y', '-i', srcPath,
+      '-ss', String(inSec), '-to', String(outSec),
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-c:a', 'aac',
+      '-avoid_negative_ts', 'make_zero',
+      outPath,
+    ],
+    'cut',
+  );
+}
+
+/**
+ * Join cut segments into one file with the concat **filter** (not the demuxer):
+ * footage segments are independently encoded, so their PTS must be rebuilt or
+ * the total duration mis-accumulates. Re-encodes to a uniform h264/aac. Keeps
+ * audio (v=1:a=1), unlike the synthesised-frame concat which is video-only.
+ */
+export async function concatClips(clipPaths: string[], outPath: string): Promise<void> {
+  if (clipPaths.length === 0) {
+    throw new HtmlVideoError('invalid-input', 'concatClips: no segments to join');
+  }
+  if (clipPaths.length === 1) {
+    await runFfmpeg(['-y', '-i', clipPaths[0]!, '-c', 'copy', outPath], 'concat');
+    return;
+  }
+  const n = clipPaths.length;
+  const inputs = clipPaths.flatMap((p) => ['-i', p]);
+  const filter =
+    clipPaths.map((_, i) => `[${i}:v][${i}:a]`).join('') + `concat=n=${n}:v=1:a=1[v][a]`;
+  await runFfmpeg(
+    [
+      '-y', ...inputs,
+      '-filter_complex', filter,
+      '-map', '[v]', '-map', '[a]',
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-c:a', 'aac',
+      '-movflags', '+faststart',
+      outPath,
+    ],
+    'concat',
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,8 +7,18 @@ export { HtmlVideoError } from './errors.js';
 export type { ErrorCode } from './errors.js';
 export { AssetStore } from './asset-store.js';
 export type { AssetStoreOptions } from './asset-store.js';
-export { EngineRegistry, TemplateRegistry, ProjectStore } from './registry.js';
+export { EngineRegistry, SourceRegistry, TemplateRegistry, ProjectStore } from './registry.js';
 export { ProjectOrchestrator } from './project.js';
+export {
+  FILLER_WORDS,
+  normalizeWord,
+  fillersIn,
+  selectTake,
+  buildFootageGraph,
+  cutClip,
+  concatClips,
+} from './footage.js';
+export type { SceneSpec, SelectOptions } from './footage.js';
 export type {
   CreateProjectInput,
   ProjectOrchestratorDeps,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -11,6 +11,7 @@ import type {
   EngineAdapter,
   EngineId,
   Project,
+  SourceAdapter,
   TemplateMetadata,
 } from './types/index.js';
 import { HtmlVideoError } from './errors.js';
@@ -42,6 +43,39 @@ export class EngineRegistry {
   }
 
   has(id: EngineId): boolean {
+    return this.adapters.has(id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SourceRegistry (RFC-11: footage ingest adapters)
+// ---------------------------------------------------------------------------
+
+/** Registry of {@link SourceAdapter}s (transcription back-ends), mirroring
+ *  {@link EngineRegistry}. Keyed by adapter id (e.g. 'whisper-local'). */
+export class SourceRegistry {
+  private adapters = new Map<string, SourceAdapter>();
+
+  register(adapter: SourceAdapter): void {
+    this.adapters.set(adapter.id, adapter);
+  }
+
+  get(id: string): SourceAdapter {
+    const a = this.adapters.get(id);
+    if (!a) {
+      throw new HtmlVideoError(
+        'engine-not-registered',
+        `Source adapter "${id}" is not registered. Did you forget to install @html-video/adapter-${id.replace(/-local$/, '')}?`,
+      );
+    }
+    return a;
+  }
+
+  list(): SourceAdapter[] {
+    return [...this.adapters.values()];
+  }
+
+  has(id: string): boolean {
     return this.adapters.has(id);
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -144,6 +144,53 @@ export interface EngineAdapter {
 }
 
 // ============================================================================
+// RFC-11: Source Adapter (footage ingest — transcription)
+// ============================================================================
+
+/** One transcribed word with its time span in the source clip, seconds. */
+export interface TranscriptWord {
+  word: string;
+  start: number;
+  end: number;
+}
+
+/** Word-level transcript of a single take. The artifact every downstream
+ *  footage decision (selection, cut points, overlay cues) is grepped from. */
+export interface Transcript {
+  /** asset.id of the take this transcript belongs to. */
+  clipAssetId: string;
+  words: TranscriptWord[];
+  language?: string;
+  /** Engine that produced it (e.g. 'whisper-local'), for provenance. */
+  source?: string;
+}
+
+export interface SourceCapabilities {
+  /** Runs entirely on the user's machine (no upload, no per-use fee). */
+  local: boolean;
+  /** Emits per-word timestamps (required for frame-accurate cutting on speech). */
+  wordTimestamps: boolean;
+  /** Supported languages, or 'auto' for auto-detect. */
+  languages: string[] | 'auto';
+  licensing: LicensingTier;
+}
+
+/**
+ * RFC-11: the ingest-side counterpart to {@link EngineAdapter}. Where an engine
+ * adapter turns a template into pixels, a source adapter turns a raw take into
+ * a usable, time-coded transcript. Default impl is `whisper-local` (on-device,
+ * free) — cloud ASR adapters expose their `licensing` so an agent can avoid
+ * them in "free / private" scenarios, the same way it avoids paid engines.
+ */
+export interface SourceAdapter {
+  id: string;
+  name: string;
+  capabilities: SourceCapabilities;
+  /** Transcribe one video/audio take into a word-level transcript. */
+  transcribe(asset: Asset, ctx: RenderContext): Promise<Transcript>;
+}
+
+// ============================================================================
 // RFC-02: Template Metadata
 // ============================================================================
 

--- a/packages/core/test/footage-select.test.mjs
+++ b/packages/core/test/footage-select.test.mjs
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fillersIn,
+  normalizeWord,
+  selectTake,
+  buildFootageGraph,
+} from '../dist/footage.js';
+
+// Build a transcript from a "Word start end" tuple list.
+function tr(clip, words) {
+  let t = 0;
+  return {
+    clipAssetId: clip,
+    words: words.map((w) => {
+      const start = t;
+      t += 0.3;
+      return { word: w, start, end: t - 0.05 };
+    }),
+  };
+}
+
+test('normalizeWord strips punctuation/case so "Ah!" and um, still match', () => {
+  assert.equal(normalizeWord('Ah!'), 'ah');
+  assert.equal(normalizeWord('um,'), 'um');
+  assert.equal(normalizeWord("it's"), 'its');
+});
+
+test('fillersIn finds disfluencies verbatim', () => {
+  const t = tr('C1', ['Hello', 'um,', 'world', '"Ah!"']);
+  assert.deepEqual(fillersIn(t.words), ['um,', '"Ah!"']);
+});
+
+test('selectTake picks the zero-filler complete take, later breaks ties', () => {
+  const transcripts = {
+    C1: tr('C1', ['We', 'um,', 'verify', 'changes.']),
+    C2: tr('C2', ['We', 'verify', 'changes.']), // clean, complete
+  };
+  const node = selectTake({ scene: 3, title: 'Verify', takes: ['C1', 'C2'] }, transcripts);
+  assert.equal(node.kind, 'footage');
+  assert.equal(node.clipAssetId, 'C2');
+  assert.equal(node.id, 'scene3');
+  assert.deepEqual(node.candidateClipAssetIds, ['C1', 'C2']);
+  assert.match(node.selectionRationale, /zero fillers/);
+  assert.match(node.selectionRationale, /C1 dropped \(fillers: um,\)/);
+  assert.ok(node.out > node.in);
+});
+
+test('selectTake trims a leading warm-up phrase from the cut-in', () => {
+  const transcripts = {
+    C3: tr('C3', ['Hey', 'everyone,', "it's", 'Joey.']),
+  };
+  const node = selectTake(
+    { scene: 1, title: 'Intro', takes: ['C3'], warmup: 'hey everyone' },
+    transcripts,
+  );
+  // cut-in should start at "it's" (index 2), not "Hey"
+  const itsStart = transcripts.C3.words[2].start;
+  assert.ok(Math.abs(node.in - (itsStart - 0.05)) < 1e-6, `in=${node.in}`);
+  assert.equal(node.firstWords.split(' ')[0], "it's");
+  assert.match(node.selectionRationale, /Warm-up "hey everyone" cut/);
+});
+
+test('buildFootageGraph chains scenes with sequence edges', () => {
+  const transcripts = {
+    A: tr('A', ['First', 'scene.']),
+    B: tr('B', ['Second', 'scene.']),
+  };
+  const g = buildFootageGraph(
+    [
+      { scene: 1, title: 'One', takes: ['A'] },
+      { scene: 2, title: 'Two', takes: ['B'] },
+    ],
+    transcripts,
+  );
+  assert.equal(g.nodes.length, 2);
+  assert.equal(g.edges.length, 1);
+  assert.deepEqual(g.edges[0], { from: 'scene1', to: 'scene2', kind: 'sequence' });
+});
+
+test('selectTake throws on a scene with no candidate takes', () => {
+  assert.throws(() => selectTake({ scene: 9, title: 'Empty', takes: [] }, {}), /no candidate takes/);
+});

--- a/research/2026-06-11-spec-11-footage-edit.md
+++ b/research/2026-06-11-spec-11-footage-edit.md
@@ -1,0 +1,253 @@
+# RFC-11：Footage Pipeline（吃真实素材 → 剪辑 + 字幕 + 动效浮层 + 合成 → 成片；把"剪辑即文本"做成一等能力）
+
+> **Status**: Draft v0.2（v0.1 只覆盖 footage-edit；v0.2 升级为**完整管线北极星图**。Phase-0 已实现+验证，见 §6 + poc-findings）
+> **Date**: 2026-06-11
+> **Scope**: 给 html-video 增加**第二条入口管线**——从原始录像出发，把它**剪成片，并把 html-video 本来就会生成的 HTML/Remotion 动效图形 + 字幕，按转录时间戳合成进真实画面**。全程剪辑决策以文本/JSON/代码存在，agent 可读、可 diff、可重渲。
+> **设计参照**: Thariq Shihipar（Anthropic Claude Code 团队）的公开案例 deck *"How Fable Edited Its Own Launch Video"*（https://thariqs.github.io/cc-video-editing-deck/，2026-06）。本 RFC 把那套手搓 repo 流程**产品化**成 html-video 的一等能力。
+> **依赖**: RFC-01（Engine Adapter）/ RFC-02（Template metadata）/ RFC-06（Content Graph）/ RFC-08（Remotion adapter）/ RFC-09（multi-engine UX）
+> **决策**: Joey 2026-06-11 拍板"**把 deck 这一整套能力（剪辑/字幕/动效配置/把动效融入视频）融入 html-video**"。Phase-0 已做；本文先把整套蓝图锁定，再逐阶段实现。
+
+---
+
+## 0. 为什么是现在做（动机）
+
+html-video 当前命题是 **"video as code"**：agent 选 engine + 模板，把 prompt / 文章 / repo **合成**为多帧动画视频（**Synthesis 路径**，已端到端跑通）。
+
+但真实世界里另一半、更高频的视频工作是"**把已有素材剪成片，并叠上动效图形和字幕**"——口播、demo 录屏、采访、发布会。Thariq 的 deck 证明了三件对 html-video 极关键的事：
+
+1. **"剪辑即文本"是真命题、有高可信背书。** 整个剪辑 = 一个 repo：`transcripts/*.json`（逐词时间戳）+ `final-edit.json`（EDL，含每个选择的书面理由）+ `luts/*.cube`（调色）+ Remotion 组件（图形）+ `anim.tsx`（全局动效旋钮）+ `FinalEdit.tsx`（字幕/浮层按词定时的 cue sheet）。"the edit is text, so Claude can read it, diff it, and re-render it." —— 跟 html-video 内核是同一句话。
+2. **deck 的后半段就是 html-video 的现成强项。** PNG→参数化 JSX 组件 = 我们的原生 Remotion 模板；全局 timing 旋钮 = 模板 inputProps；按词定时的字幕/浮层 = transcript 驱动的 cue。**html-video 本来就会"生成 HTML/Remotion 动效画面"——deck 的"动效+字幕"层我们已经有引擎，缺的只是把它接到真实素材上的"合成 + 定时"那层胶水。**
+3. **它今天是一次性手搓 repo，没有产品。** 没有可复用的 EDL/cue schema、没有 ingest/转录抽象、没有跨引擎浮层合成、没有 studio UI。这正是 meta-layer 该填的空位。
+
+**一句话动机**：html-video = "合成动效画面"的引擎；本 RFC 把它升级成 **"造 + 剪 + 把动效/字幕合成进真实视频" 的完整管线**——底层=你的真实录像，上层=html-video 本来就会生成的 HTML/Remotion 动效与字幕，**转录把两者对齐，ffmpeg 合成成片**。
+
+---
+
+## 1. deck 完整管线（12 步）与"两个半场"
+
+| # | deck 步骤 | 半场 |
+|---|---|---|
+| 1 | 转录所有 take（Whisper，逐词时间戳） | 前半：吃素材 |
+| 2 | 每场 subagent 选最佳 take + verifier | 前半 |
+| 3 | EDL（final-edit.json）：候选/in-out/书面理由 | 前半 |
+| 4 | ffmpeg 帧精确切 + 拼 → 粗剪 | 前半 |
+| 5 | 重新转录成片自检（"zero ums"） | 前半 |
+| 6 | **字幕 / lower-third / 图形：PNG → 参数化 Remotion 组件** | **后半：动效（html-video 已有引擎）** |
+| 7 | **全局动效配置：anim.tsx 6 个 timing 旋钮** | 后半 |
+| 8 | **cue sheet：浮层/字幕按转录词时间戳出现（FinalEdit.tsx）** | 后半 |
+| 9 | **把浮层合成进真实画面（alpha overlay）** | 后半（新胶水） |
+| 10 | 调色：手写 .cube LUT，ffmpeg 套用 | 后半 |
+| 11 | Figma MCP 往返 design review | 后半（可选） |
+| 12 | `npx remotion render` + 截图自检 | 后半 |
+
+**前半 = 全新**（html-video 此前完全没有素材入口）；**后半 = 大部分已有**（html-video 的动效引擎），缺"合成 + 字幕定时 + 全局配置面"的胶水。
+
+---
+
+## 2. 整套能力 → html-video 现状映射（reuse vs build）
+
+| deck 能力 | html-video 现状 | 工作量 |
+|---|---|---|
+| 一句 prompt 启动 + `/goal 不出片不停` | studio agent 编排 + runtime agent defs | ♻️ 复用 |
+| 转录（逐词时间戳） | —— | ✅ **Phase-0 已建**：`SourceAdapter` + `adapter-whisper`(whisper.cpp 本机) |
+| 选 take + 书面理由 | —— | ✅ **Phase-0 已建**：`core.selectTake`/`buildFootageGraph` |
+| EDL（候选/in-out/理由） | content-graph 泛化承载 | ✅ **Phase-0 已建**：`footage` NodeKind |
+| 帧精确切 + 拼 | core concat-filter | ✅ **Phase-0 已建**：`core.cutClip`/`concatClips` |
+| 重转录自检 | —— | ✅ **Phase-0 已建**：CLI `footage-edit` verify 段 |
+| **字幕**（按词出现） | `EngineCapabilities.subtitles` 字段早留好 | 🆕 转录→字幕块→cue（burn-in / sidecar / 渲成动效字幕组件） |
+| **HTML/动效图形浮层** | 🟡 **已有引擎**：`adapter-remotion` + 原生模板（`frame-data-rollup`） | 🆕 让它出 **alpha** + 当"浮层"用 |
+| **全局动效配置**（anim 旋钮） | 🟡 已有：模板 inputProps | 🆕 统一 `MotionConfig`，跨浮层共享 |
+| **cue sheet**（浮层卡在某词上） | 转录已有词时间戳 | 🆕 `Cue`：把浮层节点绑到时间线某时刻 |
+| **把图形/字幕融入视频**（合成） | `OutputFormat:'webm-alpha'` 已支持 | 🆕 `core.compositeOverlay`（ffmpeg overlay 滤镜） |
+| 调色 .cube | —— | 🆕 `core.applyLut`（ffmpeg lut3d） |
+| Figma 往返 | OD 生态有 Figma MCP 经验 | 🆕 Phase-3（可选） |
+| headless 渲染 + 截图自检 | adapter render + 量像素 | ♻️ 复用 |
+
+**结论**：12 步里 **5 步 Phase-0 已落**、**3 步复用现有引擎**、**4 步新建胶水**（字幕定时 / alpha 浮层 / 合成 / 调色）。新建集中、互相高内聚。
+
+---
+
+## 3. 北极星架构：分层时间线（Layered Timeline）
+
+Synthesis 与 Footage 在"**时间线上一串有序 segment**"上同构。要叠动效/字幕，再加一层"**覆盖层**"概念。
+
+### 3.1 底层时间线（base track）—— 已有 / Phase-0
+一串有序节点，每个 segment 来源二选一：
+- **合成节点**（entity/data/text）→ engine 渲染模板帧（Synthesis，已有）
+- **footage 节点**（RFC-11）→ ffmpeg 从真实素材切一段（Phase-0 已建）
+
+`sequence` 边 + topoSort 排播放顺序。**一条 graph 可混含两类节点** → 天然支持"真人口播段 + 纯动效转场"混剪。
+
+### 3.2 覆盖层（overlay layer）—— 新建（Phase-1/2）
+字幕、lower-third、数据浮层**不进 base 顺序**，而是**绑到 base 时间线的某个时间窗**，叠在画面上层。模型 = **Cue**（对齐 deck 的 `FinalEdit.tsx` CUES 数组）：
+
+```ts
+export interface Cue {
+  /** 要叠的覆盖节点 id（一个 text/data 节点，由现有引擎渲成 alpha 浮层） */
+  overlayNodeId: string;
+  /** 出现时刻：绝对秒，或锚到某 base 段 + 段内偏移（cut 后仍稳） */
+  at: number | { baseNodeId: string; offsetSec: number };
+  /** 持续秒 */
+  durSec: number;
+  /** 叠放轨道 / 层级（多个浮层共存时定 z 序与避让） */
+  track?: number;
+  /** 锚定来源：转录里哪个词触发的（可追溯，对齐 deck "grep 词时间戳定位"） */
+  anchorWord?: { clipAssetId: string; wordIndex: number };
+}
+```
+
+**定时来源 = 转录词时间戳**：agent/工具在转录里 grep 到目标短语 → 取其 start → 设 `at`。这就是 deck "no timeline scrubbing, Claude greps the word timestamps" 的产品化。
+
+### 3.3 字幕（subtitles）—— 新建（Phase-1）
+转录 → 按行长/停顿切成字幕块 → 三种出口（capability 已留 `subtitles: ('none'|'burn-in'|'sidecar')[]`）：
+- **sidecar**：导出 `.srt`/`.vtt`（最简，零依赖）
+- **渲成动效字幕组件**（推荐、最 on-brand）：每块字幕 = 一个 text 覆盖节点 + cue，由现有引擎渲成 alpha 浮层合成 → 字幕本身就是"HTML 动效"，天然带入场动画、可换样式
+- **burn-in**：ffmpeg 烧字（注意 §7 风险：brew ffmpeg 无 `drawtext`/`libass` 时此路不通，故推荐走动效字幕组件）
+
+### 3.4 合成（compositing）—— 新建（Phase-1）
+core 新原语（与 `concatClips` 同层）：
+
+```
+core/src/footage.ts （扩展）
+  compositeOverlay(basePath, overlays: {path,atSec,durSec,x,y,track}[], outPath)
+    // ffmpeg overlay 滤镜链：每个 alpha 浮层在其 [at, at+dur] 窗口叠到 base 上
+  applyLut(basePath, cubePath, outPath)   // ffmpeg lut3d（Phase-2）
+```
+
+覆盖节点渲成 **alpha**：`adapter-remotion` 出 `webm-alpha`（vp9 alpha）/ prores4444；`adapter-hyperframes` 走 Playwright `omitBackground` 截透明。两引擎都能产 alpha 浮层。
+
+### 3.5 全局动效配置（MotionConfig）—— 新建（Phase-2）
+对齐 deck `anim.tsx`："6 个数字驱动全片动效，'做快一点'=改一行"。项目级共享配置，作为 inputProps 注入所有覆盖模板：
+
+```ts
+export interface MotionConfig {
+  revealFrames?: number;     // 元素入场
+  staggerFrames?: number;    // 同级间隔
+  overlayInFrames?: number;  // 浮层滑入
+  overlayOutFrames?: number; // 淡出
+  easing?: string;           // 如 'cubic-bezier(0.16,1,0.3,1)'
+  fps?: number;
+}
+```
+
+### 3.6 SourceAdapter —— 已有 / Phase-0
+ingest 侧与 `EngineAdapter` 对称：把原始 take 转成时间编码的转录。默认 `whisper-local`（本机、免费）；云 ASR adapter 暴露 `licensing` 供 agent 在"免费/隐私"场景避开。
+
+### 3.7 EDL = content-graph 投影
+不另造文件格式：EDL = "footage 节点 + sequence 边 + rationale + cues" 的 content-graph。复用 topoSort，混剪/覆盖统一在一棵图里。
+
+---
+
+## 4. 端到端目标管线
+
+```
+takes/*.mov ─ingest→ assets[](video)
+        │
+   SourceAdapter.transcribe (whisper-local, 词时间戳)   ←✅Phase-0
+        ▼
+   transcripts/<clip>.json
+        │
+   take-selection（每场 subagent 选 + 写 rationale）    ←✅Phase-0
+        ▼
+   content-graph.json  ── base: footage 节点 + sequence 边           可读可diff
+        │                  └ overlays: text/data 节点 + cues（绑词时间戳） ←🆕P1/2
+        │
+   core.cutClip×N + concatClips ──▶ 粗剪 baseCut.mp4    ←✅Phase-0
+        │
+   SourceAdapter.transcribe(baseCut) → 比对脚本自检       ←✅Phase-0
+        │
+   ┌────┴───────── 覆盖层（🆕P1/2）─────────┐
+   │ 字幕块/数据浮层 = 覆盖节点              │
+   │  → 现有引擎渲成 webm-alpha 浮层（MotionConfig 注入）│
+   │  → core.compositeOverlay 按 cue 叠到 baseCut 上    │
+   └────┬───────────────────────────────────┘
+        │  [🆕P2] core.applyLut 调色
+        ▼
+   final.mp4 (+ soundtrack 复用 RFC-09 音频 mux)
+```
+
+---
+
+## 5. 关键 schema 增量
+
+- ✅ `FootageNode`（已建）：clipAssetId / in / out / firstWords / candidateClipAssetIds / selectionRationale
+- ✅ `Transcript` / `TranscriptWord` / `SourceAdapter`（已建）
+- 🆕 `Cue`（§3.2）：覆盖节点 → 时间窗，锚到词时间戳
+- 🆕 `ContentGraph.cues?: Cue[]`：图上挂一组覆盖 cue（base 节点走 sequence，覆盖节点走 cues，互不入序）
+- 🆕 `MotionConfig`（§3.5）：项目级全局动效旋钮
+- 🆕 `SubtitleChunk`：{ startSec, endSec, text }（转录切块产物，可转 sidecar 或覆盖节点）
+
+---
+
+## 6. 分阶段交付
+
+> 原则：每个 phase 独立可发布；Phase-0 单独已讲完"剪辑即文本"故事。
+
+### ✅ Phase 0 — 素材 → 转录 → 选片 → EDL → 粗剪 → 自检（已实现）
+落地：`content-graph` 加 `footage` 节点；`core` 加 `SourceAdapter`/`SourceRegistry`/`footage.ts`(选片+cut+concat)；新包 `adapter-whisper`（whisper.cpp 本机）；CLI `footage-edit`；6 单测；合成素材端到端 `clean:true`。详见 `2026-06-11-spec-11-poc-findings.md`。
+**遗留待补**（findings 暴露）：① ASR 语言/模型选择（auto 可能误判致幻觉，需显式 language + 幻觉短语 warning + 中文用 ≥small 模型）；② **单文件内按句切**（transcript-span 级，单 take 场景需要，Phase-0 以整文件为 take）。
+
+### Phase 1 — 字幕 + 浮层合成（接通"把动效融进真实视频"的核心卖点）
+- 转录 → `SubtitleChunk[]` → 渲成 alpha 动效字幕浮层（+ sidecar 导出兜底）。
+- `Cue` 模型 + 覆盖节点渲 alpha（adapter-remotion `webm-alpha` / hyperframes omitBackground）。
+- `core.compositeOverlay`（ffmpeg overlay）把字幕/一个数据浮层按 cue 叠到 baseCut。
+- **验收**：真人口播片段上，字幕逐句精确卡在口播词上 + 一个 lower-third 浮层在指定词出现。**这一步让"真实素材 × 我们的动效引擎"1+1>2。**
+
+### Phase 2 — 完整 cue sheet + 全局动效配置 + 段内切 + 调色
+- 多浮层 cue sheet（按词定时、轨道避让）；`MotionConfig` 全局旋钮注入所有浮层。
+- 单文件内 transcript-span 级切（补 Phase-0 遗留②）。
+- `core.applyLut`（lut3d）应用 `.cube`；可选 agent 生成 grade 候选。
+- 选片正式化：每场 subagent + verifier 双层。
+
+### Phase 3 —（可选）studio UI + Figma 往返
+- studio 加 Footage 项目类型：传 takes → 看转录 → 调 EDL/cue（拖 in/out、移浮层）→ 看合成预览。
+- Figma MCP 导出浮层组件做 design review，改完导回（deck step 6-8）。优先级最低。
+
+---
+
+## 7. 事实核对（2026-06-11）
+
+| 假设 | 核对 |
+|---|---|
+| 本机逐词转录、免费 | ✅ whisper.cpp 本地跑，word timestamps；**但语言/模型要选对**——base 在中文上会幻觉成英文（findings 实测），中文用 ≥small + 显式 `-l zh` |
+| ffmpeg 帧精确切 + 重建时间轴拼 | ✅ Phase-0 已实测，混流必须 concat-filter |
+| 覆盖浮层可带 alpha 合成 | ✅ `webm-alpha` 已在 OutputFormat；Remotion 出 vp9-alpha/prores4444；hyperframes 走 Playwright `omitBackground`；ffmpeg `overlay` 按时间窗叠 |
+| 浮层组件可参数化、按帧定时 | ✅ 原生模板范式（`frame-data-rollup`，inputProps 驱动 interpolate/spring） |
+| 字幕烧录 | ⚠️ ffmpeg `drawtext`/`subtitles(libass)` **brew 版可能没链**（本机实测 `drawtext` 不可用）→ **推荐走"动效字幕组件"路径**，sidecar `.srt/.vtt` 作兜底，burn-in 仅在 ffmpeg 带 libass 时 |
+| .cube LUT | ✅ ffmpeg `lut3d` 滤镜 |
+| content-graph 承载分层时间线 | ✅ base 走 sequence+topoSort，overlay 走 cues 不入序，加节点种类 + cues 字段即可 |
+
+来源：deck https://thariqs.github.io/cc-video-editing-deck/ · whisper.cpp https://github.com/ggml-org/whisper.cpp · ffmpeg filters（overlay/concat/lut3d/subtitles）https://ffmpeg.org/ffmpeg-filters.html · 本项目混流 concat + drawtext 缺失 + 中文幻觉教训见 poc-findings + CLAUDE.md
+
+---
+
+## 8. 风险与边界
+
+- **转录质量决定一切下游**（选片/字幕/cue 全靠时间戳）。语言/模型误判会整段幻觉（findings 实测）。缓解：显式 language + 重转录自检兜底 + 适配模型档位。
+- **大文件**：原片不进 git/.md，assets 只存路径 + metadata。
+- **字幕烧录依赖 ffmpeg 构建**：brew 版常缺 drawtext/libass → 默认走动效字幕组件，不赌 ffmpeg 字体能力。
+- **调色（P2）是深水区**：先做"应用用户给的 .cube"，"生成 LUT"作加分项不作承诺。
+- **范围蔓延**：用分阶段划清；Phase-0 已是单独可发布最小集。
+- **studio 交互不要污染 Synthesis**：Footage 是新项目类型，复用后端但 UI 独立入口（6/6 教训）。
+
+---
+
+## 9. 对外叙事价值
+
+- README/launch 强叙事：**"Not just generate video — edit your real footage, and weave your animated HTML graphics + captions right into it, all timed to what's said."** 配 deck 同款可信度（"0 video editors opened"）。
+- 四件套一致：本机 whisper + 本机 ffmpeg + 开源引擎 = 零云依赖剪辑/合成。
+- 拉开 vs Hyperframes：HF 是"HTML→视频"单一合成；html-video 变成"造 + 剪 + 把动效合成进真实视频"的完整 meta-layer。
+
+---
+
+## 10. 需 Joey 拍板的开放问题
+
+1. **Phase-1 优先级确认**：字幕 + 浮层合成是"融入"最可见的一步，建议作为 Phase-0 之后的下一刀。
+2. **字幕默认走"动效字幕组件"**（而非赌 ffmpeg burn-in）——确认这个方向？
+3. **Cue 定时锚**：默认锚到"base 段 + 段内偏移"（cut 后仍稳）而非绝对秒——确认？
+4. **Phase-0 代码何时开 PR**：已验证完整，可先合进 main 再叠 Phase-1（避免一个超大 PR）。
+5. 本 RFC 仍是 research/ 草稿，未 commit。
+
+---
+
+> Draft v0.2 · research/ 草稿，未 commit。Phase-0 代码在 `feat/footage-edit` 分支（未提交）。

--- a/research/2026-06-11-spec-11-poc-findings.md
+++ b/research/2026-06-11-spec-11-poc-findings.md
@@ -1,0 +1,57 @@
+# RFC-11 Phase-0 最小 PoC — 验证结论
+
+> **Date**: 2026-06-11 · **Status**: ✅ 跑通（合成素材自验，待 Joey 拿真实录像复跑）
+> **配套**: `2026-06-11-spec-11-footage-edit.md`（§9 开放问题 5）
+> **Driver（不进库）**: `~/Desktop/claude-code/scratch/hv-footage-edit-poc/`（`edit.py` + 合成 takes + 产物）
+
+## 验证目标
+
+只验 Phase-0 最高风险假设：**takes → 转录（词时间戳）→ 选片（带书面理由）→ 帧精确切 → concat-filter 拼 → 重转录自检**，全程决策以 JSON/文本存在。不动 schema/adapter 抽象。
+
+## 工具链（本机实测）
+
+| 工具 | 结果 |
+|---|---|
+| ffmpeg / ffprobe | 8.1.1 ✅（注意：brew 版**没链 freetype，`drawtext` 不可用**——测试片改用纯色底区分） |
+| ASR | `whisper-cpp`（brew 装）+ `ggml-base.en.bin`（141M，从 HF 下）✅ 本机 Metal 跑 |
+| TTS 造素材 | macOS `say -v Samantha` ✅ |
+| whisper word-level | `whisper-cli -m M -f x.wav -ml 1 -sow -oj` → 每词一段带 `offsets.from/to`（毫秒）✅ |
+
+## 合成素材
+
+3 scene / 7 take（每 scene 后面的 take 更干净），刻意埋：① 填充词 um/uh；② intro 开头 "Hey everyone" 暖场需切掉。复刻 deck 场景。
+
+## 结果（端到端一次通过）
+
+```
+选片：scene1→C003 / scene2→C005 / scene3→C007（全选到零填充词的那条，带 rationale）
+intro 暖场切除：final scene1 从 "it's…" 起，"Hey everyone" 已去（cut-in 0.92s 落静音间隙）
+拼接：3 段 sum=7.82s → final.mp4 7.84s，concat drift 0.02s（PTS 正确，concat-filter 教训成立）
+全解码：clean，单 video + 单 audio 流
+重转录自检：「It's Therick from the Claude Code team. Claude is a really great thought
+            partner for coding. We verify every single change before we ship it.」
+            → 填充词 = NONE ✓，三段顺序正确
+```
+
+## 关键发现 → 回填 spec
+
+1. **whisper 错词、时间戳准**——复刻 deck 现象：「Thariq→Theric」「uh→"Ah!"」「um→"um"」，但 `from/to` 毫秒级可靠，**切点足够准**。验证了 spec §7「转录质量决定下游」+「重转录自检兜底」的设计。
+2. **填充词检测要按归一化 token 匹配**——TTS 把 "uh" 读成 "Ah!"，标点/引号混入，必须 `re.sub('[^a-z]','')` 归一后再比 FILLER 集。
+3. **混流拼接结论同样适用于纯素材切片**——concat-filter 重建 PTS，drift 0.02s；若用 concat demuxer 拼重编码段会累加时间戳（本项目 6/7 已踩）。
+4. **brew ffmpeg 无 drawtext**——后续若要烧字幕/水印走别的路径（Remotion 浮层合成，正好是 Phase 1）。
+5. **EDL = content-graph 投影成立**——PoC 的 `final-edit.json`（footage 节点 + sequence 边 + rationale）就是 spec §3 提议的泛化结构的雏形，直接可演进。
+
+## 真实素材复跑发现（2026-06-11，Joey 提供一条中文口播）
+
+拿一条真实手机口播（竖屏 1080×1920 / 16s / 中文）复跑，暴露一个**重要产品风险**：
+
+- **whisper 在听不懂的语言上会幻觉**：`base.en` 和 `base`(auto) 把这条**中文**音频幻觉成一段**英文** YouTube 式字幕（"…please let us know in the comments below. See you in the next video." —— 这些是 whisper 训练集里的经典幻觉残留）。用普通模式复查 + 换 `small`+`-l zh` 才得到真实内容。
+- **三条教训 → 回填 spec**：
+  1. **语言/模型选择是一等风险**，不能默认 `en`、`auto` 也可能误判。`SourceAdapter` 应支持/鼓励显式 `language`，并对"高置信幻觉短语"give warning；小语种/中文要用 ≥`small` 模型。
+  2. **`-ml 1 -sow` 在短片段 + 弱模型上更易幻觉**；whole-clip 转录比逐段稳。验证类输出必须看内容、不能只看"有没有 filler"（filler=0 也可能是整段幻觉）。
+  3. **"重转录自检"正是兜底**：它能抓住"切出来是垃圾"的情况——这是 spec §7 设计的价值实证。
+- **另一个 scope 发现**：这条是**单条连续 take**（非多 take）。Phase-0 CLI 以"整文件=一条 take"为单位，**单文件内按句切**（transcript-span 级剪辑）是真实存在的需求但不在 Phase-0；可作 Phase-1.5。单 take 上能演示的是"剪辑即文本"（改 EDL span 删句重渲），不是"多 take 选优"。
+
+## 结论
+
+**Phase-0 的核心循环在本机真能跑通、可看成片、可自检。** spec §9 开放问题 5（要不要先 PoC）已用事实回答：**值得正式立项做 Phase-0**——风险点（ASR 词时间戳）已排除，剩下是把这套 driver 工程化进 `core` + `SourceAdapter` + content-graph `footage` 节点。


### PR DESCRIPTION
## What

A **second ingest pipeline** alongside synthesis: turn a folder of raw takes into a cut, with **every edit decision living as diffable JSON**. Productizes the core loop from Thariq Shihipar's deck *"How Fable Edited Its Own Launch Video"* — transcribe → pick the cleanest take (with written reasons) → frame-accurate cut → stitch → re-transcribe to self-verify.

This is **Phase-0** of RFC-11 (the full north-star pipeline — subtitles + HTML/Remotion animated overlays composited onto the footage + motion config + grade — is specced in `research/2026-06-11-spec-11-footage-edit.md` v0.2 for later phases).

## Changes

- **content-graph**: new `footage` NodeKind (`clipAssetId`/`in`/`out`/`firstWords`/`candidateClipAssetIds`/`selectionRationale`). An EDL is just a content-graph of footage nodes — no separate format; reuses `sequence` edges + topoSort, so footage and synthesized nodes mix in one timeline.
- **core**: `SourceAdapter`/`Transcript`/`TranscriptWord` types + `SourceRegistry` (the ingest-side counterpart to `EngineAdapter`); `footage.ts` with `selectTake`/`buildFootageGraph` (pure, unit-tested) + `cutClip`/`concatClips` (frame-accurate cut + concat-**filter**, reusing the mixed-engine PTS lesson).
- **adapter-whisper** (new package): `whisper-local` SourceAdapter — on-device word-level transcription via whisper.cpp, friendly missing-tool hints, default ingest back-end (no upload, no fee).
- **cli**: `footage-edit --takes <dir> [--scenes <json>] [--model <ggml>]` — runs the whole loop, writes `final-edit.json` (the EDL).
- **tests**: 6 unit tests for the selection logic (no whisper/ffmpeg dependency). Also fixes core's `test` script (`node --test test/` was broken on Node 26 → glob, matching the other packages).

## Verification

- `pnpm -r build` + `pnpm -r typecheck`: all 9 packages green
- `pnpm --filter @html-video/core test`: 6/6 pass
- **End-to-end on synthetic + real footage**: transcribe → select (zero-filler takes, warm-up trimmed) → cut → concat → re-transcribe self-check returns `clean: true`; output MP4 full-decodes clean (single v+a stream). Findings (incl. a real whisper language/model hallucination caught + the within-clip span-cut gap) in `research/2026-06-11-spec-11-poc-findings.md`.

## Usage

```bash
export HTMLVIDEO_WHISPER_MODEL=/path/to/ggml-base.en.bin   # brew install whisper-cpp
html-video footage-edit --takes ./takes --scenes ./scenes.json --out final.mp4
```

## Out of scope (later RFC-11 phases)

Subtitles, transcript-timed HTML/Remotion overlay compositing onto footage, global motion config, color grade, studio UI, within-clip span cutting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)