### PR TITLE
feat(runtime): add Qoder CLI agent definition

### DIFF
--- a/packages/project-studio/public/agent-icons/qoder.svg
+++ b/packages/project-studio/public/agent-icons/qoder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="#22c55e"/><path fill="#fff" d="M12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm0 2.5a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9Z"/><path fill="#fff" d="m15.5 15.5 3 3" stroke="#fff" stroke-width="2" stroke-linecap="round"/></svg>

--- a/packages/project-studio/public/app.js
+++ b/packages/project-studio/public/app.js
@@ -2931,6 +2931,7 @@ const AGENT_LOGOS = {
   'opencode': '/agent-icons/opencode.svg',
   'copilot': '/agent-icons/copilot.svg',
   'aider': '/agent-icons/aider.png',
+  'qoder-cli': '/agent-icons/qoder.svg',
 };
 const AGENT_ICON_FALLBACK = {
   'anthropic-api': '☁️',
@@ -2946,6 +2947,7 @@ const AGENT_DESC = {
   'cursor-agent': 'Cursor command line',
   'codex': 'Codex CLI (codex exec)',
   'hermes': 'Hermes ACP CLI',
+  'qoder-cli': 'Qoder CLI (qodercli -p)',
 };
 
 function openSettingsModal(tab = 'agent') {

--- a/packages/runtime/src/defs/qoder.ts
+++ b/packages/runtime/src/defs/qoder.ts
@@ -1,0 +1,40 @@
+import type { AgentDef } from '../types.js';
+
+/**
+ * Qoder CLI def (`qodercli`, by Qoder — npm `@qoder-ai/qodercli`).
+ *
+ * Qoder ships two binaries: `qoder` (the IDE / Electron wrapper) and
+ * `qodercli` (the standalone coding agent CLI, installed via npm).
+ * html-video uses the latter — it's the headless-capable one.
+ *
+ * Headless contract (same shape as Claude Code / Codex / Qwen):
+ *   echo "<prompt>" | qodercli -p - --permission-mode bypass_permissions
+ *
+ *   -p -          →  non-interactive, read prompt from stdin, print to stdout.
+ *   --permission-mode bypass_permissions  →  auto-approve all tool calls
+ *     (file writes, shell, etc.) so the session never blocks on an
+ *     interactive permission prompt the studio cannot answer.
+ *
+ * Prompt is passed via stdin (promptViaStdin: true) — avoids Windows shell
+ * escaping issues with backticks, quotes, and CJK chars in long prompts.
+ * Default stdout is plain text, so the extractor reads the fenced ```html``` block.
+ *
+ * Version probe: `qodercli -v` → e.g. "1.0.14".
+ */
+export const qoderCli: AgentDef = {
+  id: 'qoder-cli',
+  name: 'Qoder CLI',
+  bin: 'qodercli',
+  versionArgs: ['-v'],
+  buildArgs(_prompt, _ctx) {
+    // -p -: read prompt from stdin (avoids Windows shell escaping issues
+    //   with backticks, quotes, and other special chars in long prompts).
+    // --permission-mode bypass_permissions: auto-approve tool calls.
+    // --dangerously-skip-permissions: belt-and-suspenders — ensures
+    //   the sandbox layer also lifts write/edit restrictions.
+    return ['-p', '-', '--permission-mode', 'bypass_permissions', '--dangerously-skip-permissions'];
+  },
+  streamFormat: 'plain',
+  promptViaStdin: true,
+  installUrl: 'https://www.npmjs.com/package/@qoder-ai/qodercli',
+};

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -11,6 +11,7 @@ import { opencode } from './defs/opencode.js';
 import { copilot } from './defs/copilot.js';
 import { aider } from './defs/aider.js';
 import { traeCli } from './defs/trae-cli.js';
+import { qoderCli } from './defs/qoder.js';
 import type { AgentDef } from './types.js';
 
 /**
@@ -39,6 +40,7 @@ export const AGENT_DEFS: AgentDef[] = [
   opencode,
   copilot,
   aider,
+  qoderCli,
 ];
 
 export function findAgent(id: string): AgentDef | undefined {


### PR DESCRIPTION
- Add `qoder-cli` agent def using `qodercli -p -` with stdin prompt delivery to avoid Windows shell escaping issues
- Register agent in runtime registry alongside existing agents
- Add Qoder SVG icon and UI metadata (logo, description) in project-studio

Resolves #32 