### PR TITLE
fix(cli): replace chmod with cross-platform fs.chmodSync in build script

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
   "types": "./dist/index.d.ts",
   "files": ["dist", "README.md"],
   "scripts": {
-    "build": "tsc -p tsconfig.json && chmod +x dist/bin.js",
+    "build": "tsc -p tsconfig.json && node -e \"import('node:fs').then(fs=>fs.chmodSync('dist/bin.js',0o755))\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke": "node dist/smoke.js",
     "test": "npm run build && node --test --experimental-strip-types \"test/**/*.test.ts\""


### PR DESCRIPTION
## What

Replace the `chmod +x dist/bin.js` step in `packages/cli/package.json`'s build script with a cross-platform Node `fs.chmodSync` call. `chmod` is a Unix builtin that does not exist on Windows, so the existing script hard-fails on `pnpm -r build` there.

## Why

A fresh Windows clone gets:

```
packages/cli build: 'chmod' is not recognized as an internal or external command,
packages/cli build: operable program or batch file.
packages/cli build: Failed
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @html-video/cli@0.1.0 build: `tsc -p tsconfig.json && chmod +x dist/bin.js`
```

`tsc` itself succeeds — only the `chmod` step fails. The `x` bit is meaningless on Windows (cmd resolves executables by extension, not mode), so the chmod is effectively a no-op there. The change is a single line.

## How

```diff
-    "build": "tsc -p tsconfig.json && chmod +x dist/bin.js",
+    "build": "tsc -p tsconfig.json && node -e \"import('node:fs').then(fs=>fs.chmodSync('dist/bin.js',0o755))\"",
```

Tested on Windows 10 / Node 24.6.0:
- Before: `pnpm -r build` → `packages/cli` fails
- After:  `pnpm -r build` → all 22 packages build clean

## Risk

Trivial. Same end state on macOS/Linux (dist/bin.js ends up with 0o755). On Windows the syscall is a no-op, which is fine — Windows already executes `.js` via the Node shim regardless of mode bits.
