### PR TITLE
docs: explain design and frame spec attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ node packages/cli/dist/bin.js studio    # opens the studio at http://127.0.0.1:3
 
 In the studio: pick a template (or just describe a video / paste a link), chat with your agent, edit per-frame text, add a soundtrack, and export MP4.
 
+### Optional style specs
+
+Drop a `design.md` or `frame.md` file into the Studio composer when you want the agent to follow a specific brand, layout, or motion system. These files are style/motion specs, not video content: the subject still comes from your prompt, article, repo, or other attachments.
+
+See [`docs/design-frame-specs.md`](docs/design-frame-specs.md) for the convention and starter files:
+
+- [`docs/examples/design.md`](docs/examples/design.md)
+- [`docs/examples/frame.md`](docs/examples/frame.md)
+
 CLI utilities:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ In the studio: pick a template (or just describe a video / paste a link), chat w
 
 ### Optional style specs
 
-Drop a `design.md` or `frame.md` file into the Studio composer when you want the agent to follow a specific brand, layout, or motion system. These files are style/motion specs, not video content: the subject still comes from your prompt, article, repo, or other attachments.
+Drop a `design.md` or `frame.md` file into the Studio composer when you want the agent to follow a specific brand, layout, or motion system. These files are style/motion specs, not video content: the subject still comes from your prompt, article, repo, or uploaded text/data content.
 
 See [`docs/design-frame-specs.md`](docs/design-frame-specs.md) for the convention and starter files:
 

--- a/docs/design-frame-specs.md
+++ b/docs/design-frame-specs.md
@@ -2,7 +2,7 @@
 
 `design.md` and `frame.md` are optional attachment files for the Studio chat composer. Drop one into a project when you want the agent to follow a specific brand, layout, or motion system while generating the video.
 
-They are not scripts or source content. The video subject still comes from your chat prompt, article link, repo, or uploaded content. A design/frame spec only answers: "How should this look and move?"
+They are not scripts or source content. The video subject still comes from your chat prompt, article link, repo, or uploaded text/data content. A design/frame spec only answers: "How should this look and move?"
 
 ## When To Use Them
 
@@ -19,7 +19,9 @@ If you only want the video to summarize an article or explain a repo, paste the 
 
 `design.md` is best for a portable visual system. It usually describes brand tokens, typography, composition rules, and reusable components.
 
-`frame.md` is best for a specific motion frame or shot pattern. It usually describes timing, pacing, transitions, animation beats, and what should happen during a single frame or scene.
+`frame.md` is best for a reusable motion frame or shot pattern. It usually describes timing, pacing, transitions, animation beats, and how frames using that pattern should behave.
+
+Today, both `design.md` and `frame.md` apply project-wide: Studio injects detected specs into the storyboard prompt and every per-frame prompt. A single uploaded `frame.md` does not target only one generated scene. Use it to define the motion language for the whole video, not to attach instructions to one specific frame.
 
 The Studio treats both as required style/motion specs. Internally, a file is recognized as a spec when:
 
@@ -34,7 +36,9 @@ The Studio treats both as required style/motion specs. Internally, a file is rec
 4. Describe the video content normally.
 5. Generate. The agent receives the spec before ordinary content and is instructed to obey it for palette, typography, layout, and motion.
 
-You can attach a spec together with an article, repo link, screenshot, logo, or CSV. The spec controls look and motion; the other sources provide the subject matter.
+You can attach a spec together with text-like subject sources such as an article link, GitHub repo link, Markdown/text upload, or CSV/data file. The spec controls look and motion; those text/data sources provide the subject matter.
+
+Image assets such as screenshots and logos can still be uploaded as references/assets, but the current split multi-frame generation path does not treat non-text attachments as source material for the storyboard. Describe any important facts from an image in the prompt or a text/data attachment if the video content must depend on them.
 
 ## Starter design.md
 
@@ -52,4 +56,3 @@ See [`docs/examples/frame.md`](examples/frame.md).
 - For multi-frame videos, include rules for consistency across frames.
 - For data videos, describe chart scale, labels, units, and animation behavior.
 - Avoid putting actual narration or article content in the spec. Put that in the prompt or a separate attachment.
-

--- a/docs/design-frame-specs.md
+++ b/docs/design-frame-specs.md
@@ -1,0 +1,55 @@
+# design.md and frame.md
+
+`design.md` and `frame.md` are optional attachment files for the Studio chat composer. Drop one into a project when you want the agent to follow a specific brand, layout, or motion system while generating the video.
+
+They are not scripts or source content. The video subject still comes from your chat prompt, article link, repo, or uploaded content. A design/frame spec only answers: "How should this look and move?"
+
+## When To Use Them
+
+Use a spec when you need repeatable visual direction across generations:
+
+- Brand colors, typography, spacing, logos, and tone
+- A motion language: timing, easing, scale, dwell, transitions
+- A layout system: grid, safe areas, title positions, chart rules
+- Constraints the agent should obey across every frame
+
+If you only want the video to summarize an article or explain a repo, paste the link or upload the content file instead. If you want the video to look like a known design system, add `design.md` or `frame.md` alongside that content.
+
+## design.md vs frame.md
+
+`design.md` is best for a portable visual system. It usually describes brand tokens, typography, composition rules, and reusable components.
+
+`frame.md` is best for a specific motion frame or shot pattern. It usually describes timing, pacing, transitions, animation beats, and what should happen during a single frame or scene.
+
+The Studio treats both as required style/motion specs. Internally, a file is recognized as a spec when:
+
+- Its filename is `design.md` or `frame.md`, or
+- Its headings look like a design/motion spec, such as `## System`, `## Theme`, `## Tokens`, `## Motion`, `## Pacing`, or `## Composition`.
+
+## How To Use
+
+1. Create a `design.md` or `frame.md` file from one of the examples below.
+2. In Studio, select or create a project.
+3. Drag the file into the chat composer, or use the attachment button.
+4. Describe the video content normally.
+5. Generate. The agent receives the spec before ordinary content and is instructed to obey it for palette, typography, layout, and motion.
+
+You can attach a spec together with an article, repo link, screenshot, logo, or CSV. The spec controls look and motion; the other sources provide the subject matter.
+
+## Starter design.md
+
+See [`docs/examples/design.md`](examples/design.md).
+
+## Starter frame.md
+
+See [`docs/examples/frame.md`](examples/frame.md).
+
+## Tips
+
+- Keep the file short enough to be useful. A few precise sections beat a long style manifesto.
+- Use concrete values: color hex codes, font names, type sizes, spacing, durations, easing names.
+- State what is forbidden, not just what is preferred.
+- For multi-frame videos, include rules for consistency across frames.
+- For data videos, describe chart scale, labels, units, and animation behavior.
+- Avoid putting actual narration or article content in the spec. Put that in the prompt or a separate attachment.
+

--- a/docs/design-frame-specs.md
+++ b/docs/design-frame-specs.md
@@ -23,7 +23,7 @@ If you only want the video to summarize an article or explain a repo, paste the 
 
 Today, both `design.md` and `frame.md` apply project-wide: Studio injects detected specs into the storyboard prompt and every per-frame prompt. A single uploaded `frame.md` does not target only one generated scene. Use it to define the motion language for the whole video, not to attach instructions to one specific frame.
 
-The Studio treats both as required style/motion specs when the uploaded text/data file is small enough to be inlined into the prompt. Today that inline path is capped at 20,000 characters. Keep spec files concise; larger files may be treated as ordinary attachments instead of required style guidance.
+The Studio treats both as required style/motion specs only when the uploaded text/data file is small enough to be inlined into the prompt. Today that inline path is capped at 20,000 characters; files over that limit are not promoted into required spec handling. Detected specs are then passed to the agent as a 6,000-character slice, so keep specs under 6,000 characters if you want the whole file to be enforced.
 
 Within that limit, a file is recognized as a spec when:
 

--- a/docs/design-frame-specs.md
+++ b/docs/design-frame-specs.md
@@ -23,7 +23,9 @@ If you only want the video to summarize an article or explain a repo, paste the 
 
 Today, both `design.md` and `frame.md` apply project-wide: Studio injects detected specs into the storyboard prompt and every per-frame prompt. A single uploaded `frame.md` does not target only one generated scene. Use it to define the motion language for the whole video, not to attach instructions to one specific frame.
 
-The Studio treats both as required style/motion specs. Internally, a file is recognized as a spec when:
+The Studio treats both as required style/motion specs when the uploaded text/data file is small enough to be inlined into the prompt. Today that inline path is capped at 20,000 characters. Keep spec files concise; larger files may be treated as ordinary attachments instead of required style guidance.
+
+Within that limit, a file is recognized as a spec when:
 
 - Its filename is `design.md` or `frame.md`, or
 - Its headings look like a design/motion spec, such as `## System`, `## Theme`, `## Tokens`, `## Motion`, `## Pacing`, or `## Composition`.

--- a/docs/examples/design.md
+++ b/docs/examples/design.md
@@ -1,0 +1,52 @@
+# Design - Acme Launch System
+
+## System
+
+Create a confident product-launch visual system for B2B software videos. It should feel precise, modern, and high-trust.
+
+## Theme
+
+- Dark graphite background: `#101214`
+- Primary text: `#F6F3EC`
+- Muted text: `#A7ADB5`
+- Accent green: `#3CE6AC`
+- Alert accent: `#FF6A3D`
+- Avoid purple gradients, glassmorphism, beige backgrounds, and generic SaaS stock styling.
+
+## Typography
+
+- Display: `Inter Tight`, `Arial`, sans-serif
+- Body: `Inter`, `Arial`, sans-serif
+- Use strong hierarchy: one large headline, one short support line, optional small metadata.
+- Keep letter spacing at `0`.
+
+## Composition
+
+- Use a 12-column grid.
+- Keep important text inside a 120px safe margin on 1920x1080.
+- Prefer left-aligned layouts with one clear focal object.
+- Use thin rules, small labels, and restrained data chips.
+- Do not put the primary content inside a decorative card.
+
+## Components
+
+- Headline block: large, bold, max 2 lines.
+- Metric chip: label, value, unit, optional trend arrow.
+- Product frame: simple rectangle or screenshot placeholder with 8px max radius.
+- Footer metadata: small mono-style label in the lower left.
+
+## Motion
+
+- First 0.4s: background and grid fade in.
+- 0.4s to 1.1s: headline rises 24px and fades in.
+- 0.8s to 1.6s: accent rule draws from left to right.
+- 1.2s onward: metrics or product frame enter with slight stagger.
+- Use `cubic-bezier(0.16, 1, 0.3, 1)` for main movement.
+- Avoid bouncing, spinning, confetti, or excessive camera movement.
+
+## Output Rules
+
+- Full-bleed 1920x1080 unless the user asks for another aspect ratio.
+- Keep all visible text editable with `data-hv-text`.
+- Use real user-provided names, numbers, and claims. Do not invent metrics.
+

--- a/docs/examples/frame.md
+++ b/docs/examples/frame.md
@@ -1,0 +1,48 @@
+# Frame - Editorial Data Reveal
+
+## Purpose
+
+Use this frame pattern when the video needs to reveal one important number or comparison with editorial restraint.
+
+## Composition
+
+- Background: off-white `#F7F4EE`
+- Text: near-black `#151515`
+- Accent: red `#D81717`
+- Layout: 8-column editorial grid, generous margins, no centered dashboard cards.
+- Main number occupies the left 60 percent of the frame.
+- Context sentence sits below the number.
+- Source or timestamp sits in the bottom-left corner.
+
+## Text Slots
+
+- `eyebrow`: short uppercase category, max 28 characters
+- `value`: the main number, max 8 characters
+- `unit`: optional unit, max 6 characters
+- `context`: one sentence explaining why the number matters
+- `source`: short source label
+
+## Pacing
+
+- Total duration: 4 to 6 seconds.
+- 0.0s to 0.5s: background and grid lines fade in.
+- 0.4s to 1.0s: eyebrow appears.
+- 0.7s to 1.6s: main number counts or wipes in.
+- 1.2s to 2.0s: context sentence fades up.
+- 1.8s to 2.4s: source label appears.
+- Hold final layout for at least 1.5 seconds.
+
+## Motion Rules
+
+- Use linear or eased numeric rollups only when the user supplied real numeric data.
+- If the value is not numeric, use a mask reveal instead of a counter.
+- Keep movement subtle: no large rotations, no 3D, no particle effects.
+- Respect reduced-motion by showing the final static state.
+
+## Quality Bar
+
+- The number must be readable at thumbnail size.
+- The unit must not overpower the number.
+- Do not mix unrelated units in one chart.
+- Do not invent source labels or fake data.
+


### PR DESCRIPTION
 ## Summary

  Closes #64 by documenting what `design.md` and `frame.md` are, how Studio detects them, and how users can
  write their own.

  ## Changes

  - Add `docs/design-frame-specs.md` explaining:
    - what `design.md` / `frame.md` are
    - when to use them
    - how they differ from normal content attachments
    - how Studio recognizes them
    - practical writing tips
  - Add starter examples:
    - `docs/examples/design.md`
    - `docs/examples/frame.md`
  - Link the new docs from the README quick start section.

  ## Why

  Studio tells users they can drop a `design.md` / `frame.md` to lock brand and motion, but the repository
  did not explain the convention or provide a starting point.

  ## Verification

  - Docs-only change.
  - `git diff --check` passed for the changed files.